### PR TITLE
Fix the sample loop correction code.

### DIFF
--- a/src/loaders/sample.c
+++ b/src/loaders/sample.c
@@ -424,20 +424,17 @@ int load_sample(struct module_data *m, HIO_HANDLE *f, int flags, struct xmp_samp
 			if (xxs->flg & XMP_SAMPLE_LOOP_BIDIR) {
 				lpe += (xxs->lpe - xxs->lps) * 2;
 			}
-			xxs->data[lpe] = xxs->data[lpe - 2];
-			xxs->data[lpe + 1] = xxs->data[lpe - 1];
-			for (i = 0; i < 6; i++) {
-				xxs->data[lpe + 2 + i] = xxs->data[lps + i];
+
+			for (i = 0; i < 8; i++) {
+				xxs->data[lpe + i] = xxs->data[lps + i];
 			}
 		} else {
 			int lpe = xxs->lpe + unroll_extralen;
 			int lps = xxs->lps;
-			xxs->data[lpe] = xxs->data[lpe - 1];
-			for (i = 0; i < 3; i++) {
-				xxs->data[lpe + 1 + i] = xxs->data[lps + i];
+			for (i = 0; i < 4; i++) {
+				xxs->data[lpe + i] = xxs->data[lps + i];
 			}
 		}
 	}
-
 	return 0;
 }


### PR DESCRIPTION
Hello, please consider the following patch for inclusion in the official repository.

I am not sure of the exact intent of the original code but it was clearing causing quality problems as you can see below. The code was duplicating the last sample of the instrument loop end before copying samples from the loop start.

![libxmp_loopbug](https://cloud.githubusercontent.com/assets/4431372/5960691/95bfef32-a7d7-11e4-8fa5-002a47ef4d4e.png)

The picture was done while debugging [`explora.xm` by Clawz](http://modarchive.org/index.php?request=view_by_moduleid&query=140994) at roughly 23 seconds in the lead synth sounds very dirty even when spline interpolation is used.

No regression was noted on various .mod and .xm I tested.