### PR TITLE
.travis.yml: add clang-with-ASan and clang-with-MSan as "compilers"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: c
 compiler:
   - gcc
   - clang
+  - '"clang -fsanitize=address"'
+  - '"clang -fsanitize=memory"'
 
 os:
   - linux


### PR DESCRIPTION
This way, some memory safety problems will be caught earlier.

Travis is failing with this patch, because the testsuite currently triggers a few uses of uninitialized memory and and out of bounds reads.