### PR TITLE
src/depackers/vorbis.c: Fix warnings:

### DIFF
--- a/src/depackers/vorbis.c
+++ b/src/depackers/vorbis.c
@@ -978,6 +978,7 @@ static uint8 get8(vorb *z)
    return c;
    }
    #endif
+   return 0;/* silence pesky compiler warnings */
 }
 
 static uint32 get32(vorb *f)
@@ -1007,6 +1008,7 @@ static int getn(vorb *z, uint8 *data, int n)
       return 0;
    }
    #endif
+   return 0;/* silence pesky compiler warnings */
 }
 
 static void skip(vorb *z, int n)
@@ -3603,10 +3605,10 @@ static int start_decoder(vorb *f)
          c->value_bits = get_bits(f, 4)+1;
          c->sequence_p = get_bits(f,1);
          if (c->lookup_type == 1) {
-            c->lookup_values = lookup1_values(c->entries, c->dimensions);
-
+            val = lookup1_values(c->entries, c->dimensions);
+            c->lookup_values = val;
 	    /* Sanity check */
-            if (c->lookup_values <= 0) {
+            if (val <= 0) {
               return FALSE;
             }
          } else {
@@ -4296,6 +4298,7 @@ unsigned int stb_vorbis_get_file_offset(stb_vorbis *f)
    #ifndef STB_VORBIS_NO_STDIO
    return ftell(f->f) - f->f_start;
    #endif
+   return 0;/* silence pesky compiler warnings */
 }
 
 #ifndef STB_VORBIS_NO_PULLDATA_API

--- a/src/loaders/prowizard/fuchs.c
+++ b/src/loaders/prowizard/fuchs.c
@@ -96,7 +96,7 @@ static int depack_fuchs(HIO_HANDLE *in, FILE *out)
 	pat_size = hio_read32b(in);
 
 	/* Sanity check */
-	if (pat_size <= 0 || pat_size > 0x20000)
+	if (!pat_size || pat_size > 0x20000)
 		return -1;
 
 	/* read pattern data */

--- a/src/memio.c
+++ b/src/memio.c
@@ -52,7 +52,7 @@ size_t mread(void *buf, size_t size, size_t num, MFILE *m)
  	size_t should_read = size * num;
  	ptrdiff_t can_read = CAN_READ(m);
 
- 	if (size <= 0 || num <= 0 || can_read <= 0) {
+ 	if (!size || !num || can_read <= 0) {
  		return 0;
 	}
 


### PR DESCRIPTION
The lookup_values warning was valid. The other three were bogus, but silenced them anyway.

src/depackers/vorbis.c(981): Warning! W107: Missing return value for function 'get8'
src/depackers/vorbis.c(1010): Warning! W107: Missing return value for function 'getn'
src/depackers/vorbis.c(3609): Warning! W136: Comparison equivalent to 'unsigned == 0'
src/depackers/vorbis.c(4299): Warning! W107: Missing return value for function 'stb_vorbis_get_file_offset'