### PR TITLE
Fixed .it bug where Qxy would ignore the volume parameter

### DIFF
--- a/src/effects.c
+++ b/src/effects.c
@@ -684,10 +684,10 @@ void libxmp_process_fx(struct context_data *ctx, struct channel_data *xc, int ch
 		EFFECT_MEMORY_S3M(fxp);
 		if (fxp) {
 			xc->retrig.val = fxp;
+			xc->retrig.type = MSN(xc->retrig.val);
 		}
 		if (note) {
 			xc->retrig.count = LSN(xc->retrig.val) + 1;
-			xc->retrig.type = MSN(xc->retrig.val);
 		}
 		SET(RETRIG);
 		break;


### PR DESCRIPTION
This fixes a bug with the .it retrigger command (#97) where the volume parameter would be updated only on rows with a note.  With this fix, it will correctly update on any row the retrigger command is present on.