### PR TITLE
Fixed .it bug where Cxx on same row as SBx would not be ignored

### DIFF
--- a/src/effects.c
+++ b/src/effects.c
@@ -586,8 +586,11 @@ void libxmp_process_fx(struct context_data *ctx, struct channel_data *xc, int ch
 		xc->vol.fslide2 = -fxp;
 		break;
 	case FX_IT_BREAK:	/* Pattern break with hex parameter */
-		p->flow.pbreak = 1;
-		p->flow.jumpline = fxp;
+		if (!f->loop_chn)
+		{
+			p->flow.pbreak = 1;
+			p->flow.jumpline = fxp;
+		}
 		break;
 
 #endif


### PR DESCRIPTION
This fixes a bug with .it playback (#97) where, when the end of a loop (e.g. SB2) occurs on the same line as a break (e.g. C00), libxmp would attempt to break to the next pattern and go to the start of the loop at the same time.  Instead, it will now ignore the break until the loop is finished.