### PR TITLE
rename EXPORT to LIBXMP_EXPORT

### DIFF
--- a/include/xmp.h
+++ b/include/xmp.h
@@ -13,22 +13,22 @@ extern "C" {
 
 #if defined(_WIN32) && !defined(__CYGWIN__)
 # if defined(BUILDING_STATIC)
-#  define EXPORT
+#  define LIBXMP_EXPORT
 # elif defined(BUILDING_DLL)
-#  define EXPORT __declspec(dllexport)
+#  define LIBXMP_EXPORT __declspec(dllexport)
 # else
-#  define EXPORT __declspec(dllimport)
+#  define LIBXMP_EXPORT __declspec(dllimport)
 # endif
 #elif defined(__OS2__) && defined(__WATCOMC__) && defined(__SW_BD)
-#  define EXPORT __declspec(dllexport)
+#  define LIBXMP_EXPORT __declspec(dllexport)
 #elif (defined(__GNUC__) || defined(__clang__) || defined(__HP_cc)) && defined(XMP_SYM_VISIBILITY)
-# define EXPORT __attribute__((visibility ("default")))
+# define LIBXMP_EXPORT __attribute__((visibility ("default")))
 #elif defined(__SUNPRO_C) && defined(XMP_LDSCOPE_GLOBAL)
-# define EXPORT __global
+# define LIBXMP_EXPORT __global
 #elif defined(EMSCRIPTEN)
-# define EXPORT EMSCRIPTEN_KEEPALIVE
+# define LIBXMP_EXPORT EMSCRIPTEN_KEEPALIVE
 #else
-# define EXPORT 
+# define LIBXMP_EXPORT
 #endif
 
 #define XMP_NAME_SIZE		64	/* Size of module name and type */
@@ -313,45 +313,45 @@ struct xmp_frame_info {			/* Current frame information */
 
 typedef char *xmp_context;
 
-EXPORT extern const char *xmp_version;
-EXPORT extern const unsigned int xmp_vercode;
+LIBXMP_EXPORT extern const char *xmp_version;
+LIBXMP_EXPORT extern const unsigned int xmp_vercode;
 
-EXPORT xmp_context xmp_create_context  (void);
-EXPORT void        xmp_free_context    (xmp_context);
-EXPORT int         xmp_test_module     (char *, struct xmp_test_info *);
-EXPORT int         xmp_load_module     (xmp_context, char *);
-EXPORT void        xmp_scan_module     (xmp_context);
-EXPORT void        xmp_release_module  (xmp_context);
-EXPORT int         xmp_start_player    (xmp_context, int, int);
-EXPORT int         xmp_play_frame      (xmp_context);
-EXPORT int         xmp_play_buffer     (xmp_context, void *, int, int);
-EXPORT void        xmp_get_frame_info  (xmp_context, struct xmp_frame_info *);
-EXPORT void        xmp_end_player      (xmp_context);
-EXPORT void        xmp_inject_event    (xmp_context, int, struct xmp_event *);
-EXPORT void        xmp_get_module_info (xmp_context, struct xmp_module_info *);
-EXPORT char      **xmp_get_format_list (void);
-EXPORT int         xmp_next_position   (xmp_context);
-EXPORT int         xmp_prev_position   (xmp_context);
-EXPORT int         xmp_set_position    (xmp_context, int);
-EXPORT void        xmp_stop_module     (xmp_context);
-EXPORT void        xmp_restart_module  (xmp_context);
-EXPORT int         xmp_seek_time       (xmp_context, int);
-EXPORT int         xmp_channel_mute    (xmp_context, int, int);
-EXPORT int         xmp_channel_vol     (xmp_context, int, int);
-EXPORT int         xmp_set_player      (xmp_context, int, int);
-EXPORT int         xmp_get_player      (xmp_context, int);
-EXPORT int         xmp_set_instrument_path (xmp_context, char *);
-EXPORT int         xmp_load_module_from_memory (xmp_context, void *, long);
-EXPORT int         xmp_load_module_from_file (xmp_context, void *, long);
+LIBXMP_EXPORT xmp_context xmp_create_context  (void);
+LIBXMP_EXPORT void        xmp_free_context    (xmp_context);
+LIBXMP_EXPORT int         xmp_test_module     (char *, struct xmp_test_info *);
+LIBXMP_EXPORT int         xmp_load_module     (xmp_context, char *);
+LIBXMP_EXPORT void        xmp_scan_module     (xmp_context);
+LIBXMP_EXPORT void        xmp_release_module  (xmp_context);
+LIBXMP_EXPORT int         xmp_start_player    (xmp_context, int, int);
+LIBXMP_EXPORT int         xmp_play_frame      (xmp_context);
+LIBXMP_EXPORT int         xmp_play_buffer     (xmp_context, void *, int, int);
+LIBXMP_EXPORT void        xmp_get_frame_info  (xmp_context, struct xmp_frame_info *);
+LIBXMP_EXPORT void        xmp_end_player      (xmp_context);
+LIBXMP_EXPORT void        xmp_inject_event    (xmp_context, int, struct xmp_event *);
+LIBXMP_EXPORT void        xmp_get_module_info (xmp_context, struct xmp_module_info *);
+LIBXMP_EXPORT char      **xmp_get_format_list (void);
+LIBXMP_EXPORT int         xmp_next_position   (xmp_context);
+LIBXMP_EXPORT int         xmp_prev_position   (xmp_context);
+LIBXMP_EXPORT int         xmp_set_position    (xmp_context, int);
+LIBXMP_EXPORT void        xmp_stop_module     (xmp_context);
+LIBXMP_EXPORT void        xmp_restart_module  (xmp_context);
+LIBXMP_EXPORT int         xmp_seek_time       (xmp_context, int);
+LIBXMP_EXPORT int         xmp_channel_mute    (xmp_context, int, int);
+LIBXMP_EXPORT int         xmp_channel_vol     (xmp_context, int, int);
+LIBXMP_EXPORT int         xmp_set_player      (xmp_context, int, int);
+LIBXMP_EXPORT int         xmp_get_player      (xmp_context, int);
+LIBXMP_EXPORT int         xmp_set_instrument_path (xmp_context, char *);
+LIBXMP_EXPORT int         xmp_load_module_from_memory (xmp_context, void *, long);
+LIBXMP_EXPORT int         xmp_load_module_from_file (xmp_context, void *, long);
 
 /* External sample mixer API */
-EXPORT int         xmp_start_smix       (xmp_context, int, int);
-EXPORT void        xmp_end_smix         (xmp_context);
-EXPORT int         xmp_smix_play_instrument(xmp_context, int, int, int, int);
-EXPORT int         xmp_smix_play_sample (xmp_context, int, int, int, int);
-EXPORT int         xmp_smix_channel_pan (xmp_context, int, int);
-EXPORT int         xmp_smix_load_sample (xmp_context, int, char *);
-EXPORT int         xmp_smix_release_sample (xmp_context, int);
+LIBXMP_EXPORT int         xmp_start_smix       (xmp_context, int, int);
+LIBXMP_EXPORT void        xmp_end_smix         (xmp_context);
+LIBXMP_EXPORT int         xmp_smix_play_instrument(xmp_context, int, int, int, int);
+LIBXMP_EXPORT int         xmp_smix_play_sample (xmp_context, int, int, int, int);
+LIBXMP_EXPORT int         xmp_smix_channel_pan (xmp_context, int, int);
+LIBXMP_EXPORT int         xmp_smix_load_sample (xmp_context, int, char *);
+LIBXMP_EXPORT int         xmp_smix_release_sample (xmp_context, int);
 
 #ifdef __cplusplus
 }

--- a/src/control.c
+++ b/src/control.c
@@ -275,13 +275,13 @@ int xmp_channel_vol(xmp_context opaque, int chn, int vol)
 }
 
 #ifdef USE_VERSIONED_SYMBOLS
-EXPORT extern int xmp_set_player_v40__(xmp_context, int, int);
-EXPORT extern int xmp_set_player_v41__(xmp_context, int, int)
-	__attribute__((alias("xmp_set_player_v40__")));
-EXPORT extern int xmp_set_player_v43__(xmp_context, int, int)
-	__attribute__((alias("xmp_set_player_v40__")));
-EXPORT extern int xmp_set_player_v44__(xmp_context, int, int)
-	__attribute__((alias("xmp_set_player_v40__")));
+LIBXMP_EXPORT extern int xmp_set_player_v40__(xmp_context, int, int);
+LIBXMP_EXPORT extern int xmp_set_player_v41__(xmp_context, int, int)
+			__attribute__((alias("xmp_set_player_v40__")));
+LIBXMP_EXPORT extern int xmp_set_player_v43__(xmp_context, int, int)
+			__attribute__((alias("xmp_set_player_v40__")));
+LIBXMP_EXPORT extern int xmp_set_player_v44__(xmp_context, int, int)
+			__attribute__((alias("xmp_set_player_v40__")));
 
 asm(".symver xmp_set_player_v40__, xmp_set_player@XMP_4.0");
 asm(".symver xmp_set_player_v41__, xmp_set_player@XMP_4.1");
@@ -393,15 +393,15 @@ int xmp_set_player__(xmp_context opaque, int parm, int val)
 }
 
 #ifdef USE_VERSIONED_SYMBOLS
-EXPORT extern int xmp_get_player_v40__(xmp_context, int);
-EXPORT extern int xmp_get_player_v41__(xmp_context, int)
-	__attribute__((alias("xmp_get_player_v40__")));
-EXPORT extern int xmp_get_player_v42__(xmp_context, int)
-	__attribute__((alias("xmp_get_player_v40__")));
-EXPORT extern int xmp_get_player_v43__(xmp_context, int)
-	__attribute__((alias("xmp_get_player_v40__")));
-EXPORT extern int xmp_get_player_v44__(xmp_context, int)
-	__attribute__((alias("xmp_get_player_v40__")));
+LIBXMP_EXPORT extern int xmp_get_player_v40__(xmp_context, int);
+LIBXMP_EXPORT extern int xmp_get_player_v41__(xmp_context, int)
+		__attribute__((alias("xmp_get_player_v40__")));
+LIBXMP_EXPORT extern int xmp_get_player_v42__(xmp_context, int)
+		__attribute__((alias("xmp_get_player_v40__")));
+LIBXMP_EXPORT extern int xmp_get_player_v43__(xmp_context, int)
+		__attribute__((alias("xmp_get_player_v40__")));
+LIBXMP_EXPORT extern int xmp_get_player_v44__(xmp_context, int)
+		__attribute__((alias("xmp_get_player_v40__")));
 
 asm(".symver xmp_get_player_v40__, xmp_get_player@XMP_4.0");
 asm(".symver xmp_get_player_v41__, xmp_get_player@XMP_4.1");


### PR DESCRIPTION
EXPORT is a dangerously common name