### PR TITLE
API Addition: xmp_set_row

### DIFF
--- a/docs/libxmp.rst
+++ b/docs/libxmp.rst
@@ -632,6 +632,22 @@ int xmp_set_position(xmp_context c, int pos)
     The new position index, ``-XMP_ERROR_INVALID`` of the new position is
     invalid or ``-XMP_ERROR_STATE`` if the player is not in playing state.
 
+.. _xmp_set_row():
+
+int xmp_set_row(xmp_context c, int row)
+````````````````````````````````````````````
+
+  Skip replay to the given row.
+
+  **Parameters:**
+    :c: the player context handle.
+
+    :row: the row to set.
+
+  **Returns:**
+    The new row, ``-XMP_ERROR_INVALID`` if the new row is invalid or
+    ``-XMP_ERROR_STATE`` if the player is not in playing state.
+
 .. _xmp_stop_module():
 
 void xmp_stop_module(xmp_context c)

--- a/include/xmp.h
+++ b/include/xmp.h
@@ -333,6 +333,7 @@ EXPORT char      **xmp_get_format_list (void);
 EXPORT int         xmp_next_position   (xmp_context);
 EXPORT int         xmp_prev_position   (xmp_context);
 EXPORT int         xmp_set_position    (xmp_context, int);
+EXPORT int         xmp_set_row         (xmp_context, int);
 EXPORT void        xmp_stop_module     (xmp_context);
 EXPORT void        xmp_restart_module  (xmp_context);
 EXPORT int         xmp_seek_time       (xmp_context, int);

--- a/libxmp.map
+++ b/libxmp.map
@@ -61,5 +61,6 @@ XMP_4.4 {
   global:
     xmp_set_player;
     xmp_get_player;
+    xmp_set_row;
 } XMP_4.3;
 

--- a/src/control.c
+++ b/src/control.c
@@ -200,7 +200,7 @@ int xmp_set_row(xmp_context opaque, int row)
 	p->ord = p->pos;
 	p->row = row;
 	p->frame = -1;
-	f->num_rows = mod->xxp[p->pos]->rows;
+	f->num_rows = mod->xxp[mod->xxo[p->ord]]->rows;
 
 	return row;
 }

--- a/src/control.c
+++ b/src/control.c
@@ -174,6 +174,34 @@ int xmp_set_position(xmp_context opaque, int pos)
 	return p->pos;
 }
 
+int xmp_set_row(xmp_context opaque, int row)
+{
+	struct context_data *ctx = (struct context_data *)opaque;
+	struct player_data *p = &ctx->p;
+	struct module_data *m = &ctx->m;
+	struct xmp_module *mod = &m->mod;
+	int pos = p->pos;
+	if (pos < 0 || pos >= mod->len) {
+		pos = 0;
+	}
+	int pattern = mod->xxo[pos];
+
+	if (ctx->state < XMP_STATE_PLAYING)
+		return -XMP_ERROR_STATE;
+
+	if (row >= mod->xxp[pattern]->rows)
+		return -XMP_ERROR_INVALID;
+
+	/* See set_position. */
+	if (p->pos < 0)
+		p->pos = 0;
+	p->ord = p->pos;
+	p->row = row;
+	p->frame = -1;
+
+	return row;
+}
+
 void xmp_stop_module(xmp_context opaque)
 {
 	struct context_data *ctx = (struct context_data *)opaque;

--- a/src/control.c
+++ b/src/control.c
@@ -180,11 +180,13 @@ int xmp_set_row(xmp_context opaque, int row)
 	struct player_data *p = &ctx->p;
 	struct module_data *m = &ctx->m;
 	struct xmp_module *mod = &m->mod;
+	struct flow_control *f = &p->flow;
 	int pos = p->pos;
+	int pattern = mod->xxo[pos];
+
 	if (pos < 0 || pos >= mod->len) {
 		pos = 0;
 	}
-	int pattern = mod->xxo[pos];
 
 	if (ctx->state < XMP_STATE_PLAYING)
 		return -XMP_ERROR_STATE;
@@ -198,6 +200,7 @@ int xmp_set_row(xmp_context opaque, int row)
 	p->ord = p->pos;
 	p->row = row;
 	p->frame = -1;
+	f->num_rows = mod->xxp[p->pos]->rows;
 
 	return row;
 }
@@ -268,7 +271,7 @@ int xmp_channel_mute(xmp_context opaque, int chn, int status)
 	if (chn < 0 || chn >= XMP_MAX_CHANNELS) {
 		return -XMP_ERROR_INVALID;
 	}
-	
+
 	ret = p->channel_mute[chn];
 
 	if (status >= 2) {
@@ -292,7 +295,7 @@ int xmp_channel_vol(xmp_context opaque, int chn, int vol)
 	if (chn < 0 || chn >= XMP_MAX_CHANNELS) {
 		return -XMP_ERROR_INVALID;
 	}
-	
+
 	ret = p->channel_vol[chn];
 
 	if (vol >= 0 && vol <= 100) {

--- a/test-dev/Makefile.in
+++ b/test-dev/Makefile.in
@@ -52,7 +52,7 @@ API		= get_format_list create_context free_context \
 		  test_module load_module load_module_from_memory \
 		  load_module_from_file \
 		  start_player play_buffer \
-		  set_position prev_position \
+		  set_position prev_position set_row \
 		  set_player stop_module restart_module seek_time \
 		  channel_mute channel_vol inject_event scan_module
 

--- a/test-dev/test_api_set_row.c
+++ b/test-dev/test_api_set_row.c
@@ -1,0 +1,37 @@
+#include "test.h"
+
+TEST(test_api_set_row)
+{
+	xmp_context opaque;
+	struct context_data *ctx;
+	struct player_data *p;
+	int state, ret, i;
+
+	opaque = xmp_create_context();
+	ctx = (struct context_data *)opaque;
+	p = &ctx->p;
+
+	state = xmp_get_player(opaque, XMP_PLAYER_STATE);
+	fail_unless(state == XMP_STATE_UNLOADED, "state error");
+
+	ret = xmp_set_row(opaque, 0);
+	fail_unless(ret == -XMP_ERROR_STATE, "state check error");
+
+	create_simple_module(ctx, 1, 1);
+	set_order(ctx, 0, 0);
+
+	libxmp_prepare_scan(ctx);
+	libxmp_scan_sequences(ctx);
+
+	xmp_start_player(opaque, 44100, 0);
+	fail_unless(p->row == 0, "didn't start at row 0");
+
+	ret = xmp_set_row(opaque, 1);
+	fail_unless(ret == 1, "return value error");
+	xmp_play_frame(opaque);
+	fail_unless(p->row == 1, "didn't set row 1");
+
+	ret = xmp_set_row(opaque, 64);
+	fail_unless(ret == -XMP_ERROR_INVALID, "return value error");
+}
+END_TEST


### PR DESCRIPTION
This patch adds code, documentation, and unit testing for a new function, xmp_set_row, as discussed in issue #100.  I must confess, however, that I do not fully understand the purpose of the final if block in set_position, which is the reason I had to make a special case for a negative pos member of player_data.

Please review and share your thoughts.  Thank you for maintaining libxmp.