### PR TITLE
Clamp Number of IT Envelope Nodes at Load Time

### DIFF
--- a/src/loaders/it_load.c
+++ b/src/loaders/it_load.c
@@ -279,14 +279,7 @@ static int read_envelope(struct xmp_envelope *ei, struct it_envelope *env,
 	}
 
 	env->flg = buf[0];
-	env->num = buf[1];
-
-	/* Sanity check */
-	if (env->num >= XMP_MAX_ENV_POINTS) {
-		env->flg = 0;
-		env->num = 0;
-		return -1;
-	}
+	env->num = MIN(buf[1], 25); /* Clamp to IT max */
 
 	env->lpb = buf[2];
 	env->lpe = buf[3];


### PR DESCRIPTION
Previously, libxmp would return an error upon loading an IT file containing an instrument envelope with an impossibly large number of nodes.  Now, it clamps to the IT spec maximum (25).  The new behavior has been tested to match Impulse Tracker, Schism Tracker, and DUMB.