### PR TITLE
guard replacement localtime_r() with LIBXMP_CORE_PLAYER

### DIFF
--- a/src/loaders/it_load.c
+++ b/src/loaders/it_load.c
@@ -41,19 +41,22 @@ const struct format_loader libxmp_loader_it = {
 	it_load
 };
 
+#ifndef LIBXMP_CORE_PLAYER /* */
 #if defined(__WATCOMC__)
 #undef localtime_r
 #define localtime_r _localtime
 
 #elif !defined(HAVE_LOCALTIME_R) || defined(_WIN32)
 #undef localtime_r
-struct tm *localtime_r(const time_t * timep, struct tm *result)
+#define localtime_r libxmp_localtime_r
+static struct tm *libxmp_localtime_r(const time_t * timep, struct tm *result)
 {
 	/* Note: Win32 localtime() is thread-safe */
 	memcpy(result, localtime(timep), sizeof(struct tm));
 	return result;
 }
 #endif
+#endif /* ! LIBXMP_CORE_PLAYER */
 
 static int it_test(HIO_HANDLE * f, char *t, const int start)
 {


### PR DESCRIPTION
localtime_r() is used only in it_load.c and only when LIBXMP_CORE_PLAYER
is not defined. therefore add libxmp_ prefix to the replacement version,
make it static, and add the !LIBXMP_CORE_PLAYER ifdefs around it.
  