### PR TITLE
Define BUILDING_STATIC when building static library

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -55,6 +55,7 @@ esac
 
 if test "${enable_static}" = yes; then
   AC_SUBST(STATIC,static)
+  CFLAGS="${CFLAGS} -DBUILDING_STATIC"
 fi
 if test "${enable_shared}" != no; then
   AC_CHECK_DEFINED(_WIN32,[

--- a/lite/configure.ac
+++ b/lite/configure.ac
@@ -56,6 +56,7 @@ esac
 
 if test "${enable_static}" = yes; then
   AC_SUBST(STATIC,static)
+  CFLAGS="${CFLAGS} -DBUILDING_STATIC"
 fi
 if test "${enable_shared}" != no; then
   AC_CHECK_DEFINED(_WIN32,[


### PR DESCRIPTION
When trying to use this as a static library, I'd get errors about libxmp-lite.a not finding things like `__imp_xmp_release_module`.

Also, I'm not sure this is intended, but in my program I have to define BUILDING_STATIC whenever I include libxmp-lite/xmp.h to prevent it from trying to use `__imp_`-prefixed symbols as well.