### PR TITLE
Prevent Clobbering of Muted Channels' Volumes

### DIFF
--- a/src/loaders/it_load.c
+++ b/src/loaders/it_load.c
@@ -1132,7 +1132,6 @@ static int it_load(struct module_data *m, HIO_HANDLE *f, const int start)
 		}
 
 		if (ifh.chpan[i] & 0x80) {	/* Channel mute */
-			ifh.chvol[i] = 0;
 			xxc->flg |= XMP_CHANNEL_MUTE;
 		}
 


### PR DESCRIPTION
Libxmp was throwing away volume values for IT files' muted channels, even though mute status is completely independent of volume.