### PR TITLE
depackers/s404_dec.c: revise sanity checks to prevent oob reads.

### DIFF
--- a/src/depackers/s404_dec.c
+++ b/src/depackers/s404_dec.c
@@ -1,7 +1,7 @@
 /*
    StoneCracker S404 algorithm data decompression routine
    (c) 2006 Jouni 'Mr.Spiv' Korhonen. The code is in public domain.
-  
+
    from shd:
    Some portability notes. We are using int32_t as a file size, and that fits
    all Amiga file sizes. size_t is of course the right choice.
@@ -108,10 +108,10 @@ static int checkS404File(uint32 *buf, /*size_t len,*/
   if (*sLen < 0)
     return -1;
   *oLen = readmem32b((uint8 *)&buf[2]); /* Depacked length */
-  if (*oLen < 0)
+  if (*oLen <= 0)
     return -1;
   *pLen = readmem32b((uint8 *)&buf[3]); /* Packed length */
-  if (*pLen < 0)
+  if (*pLen <= 6)
     return -1;
 
   return 0;
@@ -381,7 +381,8 @@ static int decrunch_s404(FILE *in, /* size_t s, */ FILE *out)
 
   if (fstat(fileno(in), &st))
     return -1;
-        
+  if (st.st_size <= 16)
+    return -1;
   src = buf = malloc(st.st_size);
   if (src == NULL)
     return -1;
@@ -395,7 +396,7 @@ static int decrunch_s404(FILE *in, /* size_t s, */ FILE *out)
   }
 
   /* Sanity check */
-  if (oLen < 0 || pLen < 0 || pLen + 16 < 0 || pLen + 16 >= st.st_size) {
+  if (pLen > st.st_size - 18) {
     goto error;
   }
 


### PR DESCRIPTION
E.g.: one fuzz file gave the following valgrind warnings:

==21740== Invalid read of size 1
==21740==    at 0x401B314: readmem16b (dataio.c:174)
==21740==    by 0x407B0CE: initGetb (s404_dec.c:49)
==21740==    by 0x407B2F3: decompressS404 (s404_dec.c:134)
==21740==    by 0x407BA83: decrunch_s404 (s404_dec.c:408)
==21740==    by 0x4028D37: decrunch (load.c:208)
==21740==    by 0x402964E: xmp_load_module (load.c:498)
==21740==    by 0x804AEF0: main (main.c:398)
==21740==  Address 0x411597d is 0 bytes after a block of size 20,573 alloc'd
==21740==    at 0x40072B2: malloc (vg_replace_malloc.c:270)
==21740==    by 0x407B9A6: decrunch_s404 (s404_dec.c:385)
==21740==    by 0x4028D37: decrunch (load.c:208)
==21740==    by 0x402964E: xmp_load_module (load.c:498)
==21740==    by 0x804AEF0: main (main.c:398)