### PR TITLE
Fix GDM loader to correctly handle empty notes

### DIFF
--- a/src/loaders/gdm_load.c
+++ b/src/loaders/gdm_load.c
@@ -324,7 +324,8 @@ static int gdm_load(struct module_data *m, HIO_HANDLE *f, const int start)
 
 			if (c & 0x20) {		/* note and sample follows */
 				k = hio_read8(f);
-				event->note = 12 + 12 * MSN(k & 0x7f) + LSN(k);
+				/* 0 is empty note */
+				event->note = k ? 12 + 12 * MSN(k & 0x7f) + LSN(k) : 0;
 				event->ins = hio_read8(f);
 				len -= 2;
 			}


### PR DESCRIPTION
This patches the GDM loader so it will correctly handle empty notes instead of trying to convert them like a regular note. This fixes STARDSTM.GDM (issue #147), which relies on empty notes.