### PR TITLE
Fix test-dev builds for Windows

### DIFF
--- a/test-dev/main.c
+++ b/test-dev/main.c
@@ -10,6 +10,9 @@
 #include "test.h"
 #include "../src/list.h"
 
+/* Hack to fix Windows builds. */
+#include "../src/win32.c"
+
 
 struct test {
 	struct list_head list;


### PR DESCRIPTION
This hack fixes test-dev builds for Windows (tested with MSYS2 3.0.7). I don't know if this is the particular fix you actually want for this or if it's something you want at all, but this worked for me.