### PR TITLE
test-dev build fixes

### DIFF
--- a/test-dev/Makefile.in
+++ b/test-dev/Makefile.in
@@ -357,7 +357,7 @@ TEST_DFILES	= Makefile $(TEST_OBJS:.o=.c) test.h md5.h data
 TEST_PATH	= .
 SRC_PATH	= ../src
 
-TEST_INTERNAL	= hio.o load_helpers.o loaders/itsex.o dataio.o scan.o \
+TEST_INTERNAL	= win32.o hio.o load_helpers.o loaders/itsex.o dataio.o scan.o \
 		  loaders/sample.o loaders/common.o period.o fnmatch.o memio.o
 
 T_OBJS 		= $(addprefix $(TEST_PATH)/,$(TEST_OBJS)) \

--- a/test-dev/md5.h
+++ b/test-dev/md5.h
@@ -25,18 +25,14 @@ typedef struct MD5Context {
 	uint8 buffer[MD5_BLOCK_LENGTH];	/* input buffer */
 } MD5_CTX;
 
-#ifndef __sun
-#include <sys/cdefs.h>
-#endif
-
-#ifndef __sun
-__BEGIN_DECLS
+#ifdef __cplusplus
+extern "C" {
 #endif
 void	 MD5Init(MD5_CTX *);
 void	 MD5Update(MD5_CTX *, const unsigned char *, size_t);
 void	 MD5Final(uint8[MD5_DIGEST_LENGTH], MD5_CTX *);
-#ifndef __sun
-__END_DECLS
+#ifdef __cplusplus
+}
 #endif
 
 #endif /* XMP_MD5_H_ */


### PR DESCRIPTION
test-dev/md5.h: remove dependency on sys/cdefs.h .
test-dev/Makefile.in: add win32.o to TEST_INTERNAL objects list.
