### PR TITLE
depackers/vorbis.c: fix sanity check error returns

### DIFF
--- a/src/depackers/vorbis.c
+++ b/src/depackers/vorbis.c
@@ -712,10 +712,9 @@ static int compute_codewords(Codebook *c, uint8 *len, int n, uint32 *values)
    for (k=0; k < n; ++k) if (len[k] < NO_CODE) break;
 
    // sanity check
-   if (k == n) return -1;
-   if (len[k] >= 32) return -1;
+   if (k == n) return (c->sorted_entries == 0);
+   if (len[k] >= 32) return FALSE;
 
-   if (k == n) { assert(c->sorted_entries == 0); return TRUE; }
    // add to the list
    add_entry(c, 0, k, m++, len[k], values);
    // add all available leaves

--- a/src/depackers/vorbis.c
+++ b/src/depackers/vorbis.c
@@ -3608,7 +3608,7 @@ static int start_decoder(vorb *f)
             c->lookup_values = val;
 	    /* Sanity check */
             if (val <= 0) {
-              return FALSE;
+              return error(f, VORBIS_invalid_setup);
             }
          } else {
             c->lookup_values = c->entries * c->dimensions;
@@ -3655,7 +3655,7 @@ static int start_decoder(vorb *f)
                   /* Sanity check */
                   if (div == 0) {
                     free(mults);
-                    return FALSE;
+                    return error(f, VORBIS_invalid_setup);
                   }
                }
             }
@@ -3682,11 +3682,11 @@ static int start_decoder(vorb *f)
             /* Sanity check */
             if (c->sparse) {
                if (c->lookup_values > c->sorted_entries * c->dimensions) {
-                  return FALSE;
+                  return error(f, VORBIS_invalid_setup);
                }
             } else {
                if (c->lookup_values > c->entries * c->dimensions) {
-                  return FALSE;
+                  return error(f, VORBIS_invalid_setup);
                }
             }
 
@@ -3791,7 +3791,7 @@ static int start_decoder(vorb *f)
 
       /* Sanity check */
       if (r->end - r->begin > 1024) {
-        return FALSE;
+        return error(f, VORBIS_invalid_setup);
       }
 
       r->part_size = get_bits(f,24)+1;
@@ -3818,7 +3818,7 @@ static int start_decoder(vorb *f)
 
       /* Sanity check */
       if (r->classbook >= f->codebook_count) {
-         return -1;
+         return error(f, VORBIS_invalid_setup);
       }
 
       // precompute the classifications[] array to avoid inner-loop mod/divide


### PR DESCRIPTION
1. compute_codewords():
- compute_codewords() returns success (boolean), not error: replace one
  instance of negative return with FALSE.
- the (k == n) sanity check was duplicated: remove the libxmp-added one
  and just return (c->sorted_entries == 0) replacing the assert() along
  the way.

2. start_decoder():
- sanity checks added by libxmp hadn't set the error value, now they do.
  also fixes a wrong return value of -1 instead of FALSE.
