### PR TITLE
Fix GDM fine extended effects continue

### DIFF
--- a/src/loaders/gdm_load.c
+++ b/src/loaders/gdm_load.c
@@ -60,6 +60,7 @@ static int gdm_test(HIO_HANDLE *f, char *t, const int start)
 
 void fix_effect(uint8 *fxt, uint8 *fxp)
 {
+	int h, l;
 	switch (*fxt) {
 	case 0x00:			/* no effect */
 		*fxp = 0;
@@ -80,8 +81,48 @@ void fix_effect(uint8 *fxt, uint8 *fxp)
 	case 0x0b:
 	case 0x0c:
 	case 0x0d:
-	case 0x0e:
 	case 0x0f:			/* same as protracker */
+		break;
+	case 0x0e:
+		/* Convert some extended effects to their S3M equivalents. This is
+		 * necessary because the continue effects were left as the original
+		 * effect (e.g. FX_VOLSLIDE for the fine volume slides) by 2GDM!
+		 * Otherwise, these should be the same as protracker.
+		 */
+		h = MSN(*fxp);
+		l = LSN(*fxp);
+		switch(h) {
+			case EX_F_PORTA_UP:
+				*fxt = FX_PORTA_UP;
+				*fxp = l | 0xF0;
+				break;
+			case EX_F_PORTA_DN:
+				*fxt = FX_PORTA_DN;
+				*fxp = l | 0xF0;
+				break;
+			case 0x8:	/* extra fine portamento up */
+				*fxt = FX_PORTA_UP;
+				*fxp = l | 0xE0;
+				break;
+			case 0x9:	/* extra fine portamento down */
+				*fxt = FX_PORTA_DN;
+				*fxp = l | 0xE0;
+				break;
+			case EX_F_VSLIDE_UP:
+				/* Don't convert 0 as it would turn into volume slide down... */
+				if (l) {
+					*fxt = FX_VOLSLIDE;
+					*fxp = (l << 4) | 0xF;
+				}
+				break;
+			case EX_F_VSLIDE_DN:
+				/* Don't convert 0 as it would turn into volume slide up... */
+				if (l) {
+					*fxt = FX_VOLSLIDE;
+					*fxp = l | 0xF0;
+				}
+				break;
+		}
 		break;
 	case 0x10:			/* arpeggio */
 		*fxt = FX_S3M_ARPEGGIO;
@@ -367,7 +408,7 @@ static int gdm_load(struct module_data *m, HIO_HANDLE *f, const int start)
 			return -1;
 	}
 
-	m->quirk |= QUIRK_ARPMEM;
+	m->quirk |= QUIRK_ARPMEM | QUIRK_FINEFX;
 
 	return 0;
 }


### PR DESCRIPTION
This branch fixes playback of GDM fine slide effects that are followed by continue effects. Since GDMs were typically converted S3Ms, they sometimes contain effect continue commands intended for fine effects (e.g. `A00` to continue `EA4`). The easiest way to fix this was to just enable `QUIRK_FINEFX` for GDMs and convert these effects back to their S3M equivalents. The following extended effects are affected:

* `EX_F_PORTA_UP` → `FX_PORTA_UP` (`Fy`)
* `EX_F_PORTA_DN` → `FX_PORTA_DN` (`Fy`)
* `0x8` → `FX_PORTA_UP` (`Ey`)
* `0x9` → `FX_PORTA_DN` (`Ey`)
* `EX_F_VSLIDE_UP` → `FX_VOLSLIDE` (`xF`)
* `EX_F_VSLIDE_DN` → `FX_VOLSLIDE` (`Fy`)

These changes are based on [MenTaLguY's GDM format documentation](https://github.com/AliceLR/megazeux/blob/master/contrib/gdm2s3m/doc/gdm.txt). If you're suspicious about the documentation of `0x8` and `0x9` like I was at first, you should know that the MOD handler from [Bells, Whistles, and Sound Boards' 2GDM.C](https://www.phatcode.net/downloads.php?id=170) converts MOD `0x8` and `0x9` to different extended commands.

Example file that relies on continuing fine volume slides: [LB2_7.GDM.zip](https://github.com/cmatsuoka/libxmp/files/4464212/LB2_7.GDM.zip)
