### PR TITLE
Make xmp_set_position consistently clear pattern break/jump vars

### DIFF
--- a/src/control.c
+++ b/src/control.c
@@ -121,6 +121,9 @@ static void set_position(struct context_data *ctx, int pos, int dir)
 			} else {
 				p->pos = pos;
 			}
+			f->jumpline = 0;
+			f->jump = -1;
+			f->pbreak = 0;
 		}
 	}
 }


### PR DESCRIPTION
Currently, `xmp_set_position`/`xmp_next_position`/et al. do not consistently clear the pattern break and jump variables in the player flow struct, meaning if these functions are called between this effect being used and the next row playing, the first row of the position set by `xmp_set_position`/etc. will play and then the pattern break or pattern jump will immediately take effect. Believe it or not, this was actually causing an audio bug in [a MegaZeux game](https://www.digitalmzx.com/show.php?id=2223) due to some unfortunate timing.

This patch simply makes these functions clear the relevant pattern flow variables whenever the player position is modified. It might also be necessary to clear `f->loop_chn` and `f->rowdelay` (not entirely sure).