### PR TITLE
Fix leaks caused by fdopen in xmp_load_module_from_file

### DIFF
--- a/src/load.c
+++ b/src/load.c
@@ -578,7 +578,7 @@ int xmp_load_module_from_file(xmp_context opaque, void *file, long size)
 	struct context_data *ctx = (struct context_data *)opaque;
 	struct module_data *m = &ctx->m;
 	HIO_HANDLE *h;
-	FILE *f = fdopen(fileno((FILE *)file), "rb");
+	FILE *f = (FILE *)file;
 	int ret;
 
 	if ((h = hio_open_file(f)) == NULL)

--- a/src/load.c
+++ b/src/load.c
@@ -581,8 +581,12 @@ int xmp_load_module_from_file(xmp_context opaque, void *file, long size)
 	FILE *f = (FILE *)file;
 	int ret;
 
-	if ((h = hio_open_file(f)) == NULL)
+	if ((h = hio_open_file(f)) == NULL) {
+		/* Close the provided file since hio_close will close it
+		 * in the general case. */
+		fclose(f);
 		return -XMP_ERROR_SYSTEM;
+	}
 
 	if (ctx->state > XMP_STATE_UNLOADED)
 		xmp_release_module(opaque);


### PR DESCRIPTION
This fixes file descriptor/memory leaks caused by incorrect usage of `fdopen()` as described in issue #167. The short version is that [this behavior is nonportable](https://man7.org/linux/man-pages/man3/fdopen.3.html) and tricks the operating system into thinking two file descriptors are open. The original `FILE *` and the `FILE *` opened by `fdopen()` can not be safely closed separately, meaning this necessarily leaks both a file descriptor (as far as the OS is concerned) and memory (the second `FILE` struct).

The way this fix is implemented means `xmp_load_module_from_file` will always close the provided `FILE *`, but it was essentially already doing this anyway.