### PR TITLE
tempfile.c: include common.h to retrieve libxmp_snprintf() defines.

### DIFF
--- a/src/tempfile.c
+++ b/src/tempfile.c
@@ -36,6 +36,7 @@
 #include <sys/stat.h>
 #endif
 
+#include "common.h" /* for libxmp_snprintf */
 #include "tempfile.h"
 
 #ifdef _WIN32


### PR DESCRIPTION
this has been missed for quite some time.