### PR TITLE
Don't use libxmp_snprintf for MSVC 2015+ and MinGW

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -146,10 +146,23 @@ void __inline CLIB_DECL D_(const char *text, ...) { do {} while (0); }
 #define unlink _unlink
 #endif
 #if defined(_WIN32) || defined(__WATCOMC__) /* in win32.c */
+#define USE_LIBXMP_SNPRINTF
+/* MSVC 2015+ has C99 compliant snprintf and vsnprintf implementations.
+ * If __USE_MINGW_ANSI_STDIO is defined for MinGW (which it is by default),
+ * compliant implementations will be used instead of the broken MSVCRT
+ * functions. Additionally, GCC may optimize some calls to those functions. */
+#if defined(_MSC_VER) && _MSC_VER >= 1900
+#undef USE_LIBXMP_SNPRINTF
+#endif
+#if defined(__MINGW32__) && defined(__USE_MINGW_ANSI_STDIO) && (__USE_MINGW_ANSI_STDIO != 0)
+#undef USE_LIBXMP_SNPRINTF
+#endif
+#ifdef USE_LIBXMP_SNPRINTF
 int libxmp_vsnprintf(char *, size_t, const char *, va_list);
 int libxmp_snprintf (char *, size_t, const char *, ...);
 #define snprintf  libxmp_snprintf
 #define vsnprintf libxmp_vsnprintf
+#endif
 #endif
 
 /* Quirks */

--- a/src/win32.c
+++ b/src/win32.c
@@ -1,10 +1,11 @@
 /* _[v]snprintf() from msvcrt.dll might not nul terminate */
 /* OpenWatcom-provided versions seem to behave the same... */
 
-#if defined(_WIN32) || defined(__WATCOMC__)
-
 #include <stdarg.h>
 #include <stdio.h>
+#include "common.h"
+
+#if defined(USE_LIBXMP_SNPRINTF)
 
 #undef snprintf
 #undef vsnprintf


### PR DESCRIPTION
The usage of libxmp_snprintf and libxmp_vsnprintf in Windows not necessary for MSVC 2015+ and for MinGW with `__USE_MINGW_ANSI_STDIO` defined (which appears to be the default), as C99 compliant versions of these functions will be used in these cases. Using these functions (which exist in a separate compilation unit) instead of the regular implementations prevents potential optimizations that compilers may be able to do [when snprintf is a built-in function](https://gcc.gnu.org/onlinedocs/gcc-5.2.0/gcc/Other-Builtins.html).

[MSVC documentation of snprintf](https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/snprintf-snprintf-snprintf-l-snwprintf-snwprintf-l?view=vs-2019) notes that since MSVC 2015, snprintf is C99 compliant.
[MSVC documentation of vsnprintf](https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/vsnprintf-vsnprintf-vsnprintf-l-vsnwprintf-vsnwprintf-l?view=vs-2019) notes that since MSVC 2015, vsnprintf is C99 compliant.
[_MSC_VER magic number for MSVC 2015](https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=vs-2019).