### PR TITLE
Fix volume event handling for .FAR modules.

### DIFF
--- a/src/loaders/far_load.c
+++ b/src/loaders/far_load.c
@@ -231,10 +231,8 @@ static int far_load(struct module_data *m, HIO_HANDLE *f, const int start)
 	    if (event->note || ins)
 		event->ins = ins + 1;
 
-	    vol = 16 * LSN(vol) + MSN(vol);
-
-	    if (vol)
-		event->vol = vol - 0x10;	/* ? */
+	    if (vol >= 0x01 && vol <= 0x10)
+		event->vol = (vol - 1) * 16 + 1;
 
 	    event->fxt = fx[MSN(fxb)];
 	    event->fxp = LSN(fxb);


### PR DESCRIPTION
This patch fixes the handling of volume events in .FAR modules, which caused a weird bug where 0 volume events would be ignored. Despite [what the .FAR documentation says](https://modland.com/pub/documents/format_documentation/Farandole%20Composer%20(.far).txt), .FAR volume events are encoded like:

* `0x00` → no change
* `0x01` → volume=0
* `0x02` → volume=1
...
* `0x10` → volume=15

I generated some raw pattern data dumps to compare to screenshots from Farandole Composer to show this. The third byte is the volume. `0x00` is shown as blank spaces. I omitted parts of the patterns so there's less text to sift through.

[rainruin.far.zip](https://github.com/cmatsuoka/libxmp/files/5400091/rainruin.far.zip)
![rainruin2](https://user-images.githubusercontent.com/1750531/96418015-636d7980-11af-11eb-874f-1780427c988c.png)
```
: pattern 16: length=2050, expected_rows=32, break byte=30, difference=2
: 05 01 0a b8:          b8:          b8:          b8:          b8:          b8:       0f   :       0f   :       0f   :       0f   :       01   :          b8:
:            :            :            :            :            :            :       0e   :       0e   :       0e   :       0e   :            :            :
:            : 0c 01 0a   :            :            :            :            :       0d   :       0d   :       0d   :       0d   :            :            :
:            :            :            :            :            :            :       0c   :       0c   :       0c   :       0c   :            :            :
:            :            : 11 01 0a   :            :            :            :       0b   :       0b   :       0b   :       0b   :            :            :
:            :            :            :            :            :            :       0a   :       0a   :       0a   :       0a   :            :            :
:            :            :            : 18 01 0a   :            :            :       09   :       09   :       09   :       09   :            :            :
:            :            :            :            :            :            :       08   :       08   :       08   :       08   :            :       0f   :
: 03 01 0a   :            :            :            :            :            :       07   :       07   :       07   :       07   :            :       0e   :
:            :            :            :            :            :            :       06   :       06   :       06   :       06   :            :       0d   :
:            : 0d 01 0a   :            :            :            :            :       05   :       05   :       05   :       05   :            :       0c   :
:            :            :            :            :            :            :       04   :       04   :       04   :       04   :            :       0b   :
:            :            : 18 01 0a   :            :            :            :       03   :       03   :       03   :       03   :            :       0a   :
:            :            :            :            :            :            :       02   :       02   :       02   :       02   :            :       09   :
:            :            :            : 1d 01 0a   :            :            :       01   :       01   :       01   :       01   :            :       08   :
:            :            :            :            :            :            :            :            :            :            :            :       07   :
: 01 01 0a   :            : 0d 01 0a   :            :            :            :            :            :            :            :            :       06   :
:            :            :            :            :            :            :            :            :            :            :            :       05   :
:            : 22 01 0a   :            :            :            :            :            :            :            :            :            :       04   :
:            :            :            :            :            :            :            :            :            :            :            :       03   :
:            :            : 24 01 0a   :            :            :            :            :            :            :            :            :       02   :
:            :            :            :            :            :            :            :            :            :            :            :       01   :
```

[m31.far.zip](https://github.com/cmatsuoka/libxmp/files/5400101/m31.far.zip)
[m31.png](https://user-images.githubusercontent.com/1750531/96418095-8304a200-11af-11eb-8822-04b1a2ee5439.png)
[m31.txt](https://github.com/cmatsuoka/libxmp/files/5400104/m31.txt)

[residual ambient amperage.far.zip](https://github.com/cmatsuoka/libxmp/files/5400105/residual.ambient.amperage.far.zip)
[residual.png](https://user-images.githubusercontent.com/1750531/96418142-90219100-11af-11eb-80a5-e83b31adc3e5.png)
[residual.txt](https://github.com/cmatsuoka/libxmp/files/5400106/residual.txt)