### PR TITLE
don't use fdopen() in hio_open_file, leave closing the file to caller:

### DIFF
--- a/docs/libxmp.rst
+++ b/docs/libxmp.rst
@@ -359,7 +359,8 @@ int xmp_load_module_from_file(xmp_context c, FILE \*f, long size)
     :c: the player context handle.
  
     :f: the file stream. On return, the stream position is undefined.
- 
+      Caller is responsible for closing the file stream.
+
     :size: the size of the module, or 0 if the size is unknown or not
       specified. If size is set to 0 certain module formats won't be
       recognized, the MD5 digest will not be set, and module-specific

--- a/src/hio.h
+++ b/src/hio.h
@@ -18,6 +18,7 @@ typedef struct {
 		MFILE *mem;
 	} handle;
 	int error;
+	int noclose;
 } HIO_HANDLE;
 
 int8	hio_read8s	(HIO_HANDLE *);
@@ -36,6 +37,7 @@ int	hio_error	(HIO_HANDLE *);
 HIO_HANDLE *hio_open	(const void *, const char *);
 HIO_HANDLE *hio_open_mem  (const void *, long);
 HIO_HANDLE *hio_open_file (FILE *);
+HIO_HANDLE *hio_open_file2 (FILE *);
 int	hio_close	(HIO_HANDLE *);
 long	hio_size	(HIO_HANDLE *);
 

--- a/src/load.c
+++ b/src/load.c
@@ -219,7 +219,7 @@ static int decrunch(HIO_HANDLE **h, const char *filename, char **temp)
 	}
 
 	hio_close(*h);
-	*h = hio_open_file(t);
+	*h = hio_open_file2(t);
 
 	return res;
 
@@ -578,10 +578,9 @@ int xmp_load_module_from_file(xmp_context opaque, void *file, long size)
 	struct context_data *ctx = (struct context_data *)opaque;
 	struct module_data *m = &ctx->m;
 	HIO_HANDLE *h;
-	FILE *f = fdopen(fileno((FILE *)file), "rb");
 	int ret;
 
-	if ((h = hio_open_file(f)) == NULL)
+	if ((h = hio_open_file((FILE *)file)) == NULL)
 		return -XMP_ERROR_SYSTEM;
 
 	if (ctx->state > XMP_STATE_UNLOADED)

--- a/src/loaders/alm_load.c
+++ b/src/loaders/alm_load.c
@@ -153,7 +153,7 @@ static int alm_load(struct module_data *m, HIO_HANDLE *f, const int start)
 
 	mod->xxi[i].sub = calloc(sizeof (struct xmp_subinstrument), 1);
 	snprintf(filename, NAME_SIZE, "%s.%d", basename, i + 1);
-	s = hio_open_file(filename, "rb");
+	s = hio_open(filename, "rb");
 
 	if (s == NULL)
 	    continue;

--- a/src/loaders/pw_load.c
+++ b/src/loaders/pw_load.c
@@ -106,10 +106,11 @@ static int pw_load(struct module_data *m, HIO_HANDLE *h, const int start)
 		fclose(temp);
 		goto err2;
 	}
-	
+
 	/* Module loading */
 
-	if ((f = hio_open_file(temp)) == NULL) {
+	if ((f = hio_open_file2(temp)) == NULL) {
+		fclose(temp);
 		goto err2;
 	}
 
@@ -134,7 +135,7 @@ static int pw_load(struct module_data *m, HIO_HANDLE *h, const int start)
 	if (memcmp(mh.magic, "M.K.", 4)) {
 		goto err3;
 	}
-		
+
 	mod->ins = 31;
 	mod->smp = mod->ins;
 	mod->chn = 4;

--- a/src/loaders/ssmt_load.c
+++ b/src/loaders/ssmt_load.c
@@ -192,7 +192,7 @@ static int mtp_load(struct module_data *m, HIO_HANDLE *f, const int start)
 			strncat(filename, "/", NAME_SIZE);
 		strncat(filename, (char *)mod->xxi[i].name, NAME_SIZE);
 
-		if ((s = hio_open_file(filename, "rb")) != NULL) {
+		if ((s = hio_open(filename, "rb")) != NULL) {
 			asif_load(m, s, i);
 			hio_close(s);
 		}


### PR DESCRIPTION
cf.: https://github.com/cmatsuoka/libxmp/pull/173

for internal uses of hio_open_file, invent new hio_open_file2() which
does allow the library to close the file.