### PR TITLE
Fix GCC stringop-truncation warnings.

### DIFF
--- a/src/load.c
+++ b/src/load.c
@@ -351,8 +351,11 @@ int xmp_test_module(char *path, struct xmp_test_info *info)
 
 			if (info != NULL && !is_prowizard) {
 				strncpy(info->name, buf, XMP_NAME_SIZE - 1);
+				info->name[XMP_NAME_SIZE - 1] = '\0';
+
 				strncpy(info->type, format_loader[i]->name,
 							XMP_NAME_SIZE - 1);
+				info->type[XMP_NAME_SIZE - 1] = '\0';
 			}
 			return 0;
 		}

--- a/src/loaders/amf_load.c
+++ b/src/loaders/amf_load.c
@@ -78,7 +78,8 @@ static int amf_load(struct module_data *m, HIO_HANDLE *f, const int start)
 	ver = hio_read8(f);
 
 	hio_read(buf, 1, 32, f);
-	strncpy(mod->name, (char *)buf, 32);
+	memcpy(mod->name, buf, 32);
+	mod->name[32] = '\0';
 	libxmp_set_type(m, "DSMI %d.%d AMF", ver / 10, ver % 10);
 
 	mod->ins = hio_read8(f);

--- a/src/loaders/gal4_load.c
+++ b/src/loaders/gal4_load.c
@@ -68,9 +68,10 @@ static int get_main(struct module_data *m, int size, HIO_HANDLE *f, void *parm)
 	struct xmp_module *mod = &m->mod;
 	char buf[64];
 	int flags;
-	
+
 	hio_read(buf, 1, 64, f);
 	strncpy(mod->name, buf, 63);	/* ensure string terminator */
+	mod->name[63] = '\0';
 	libxmp_set_type(m, "Galaxy Music System 4.0");
 
 	flags = hio_read8(f);

--- a/src/loaders/gal5_load.c
+++ b/src/loaders/gal5_load.c
@@ -73,9 +73,10 @@ static int get_init(struct module_data *m, int size, HIO_HANDLE *f, void *parm)
 	struct local_data *data = (struct local_data *)parm;
 	char buf[64];
 	int flags;
-	
+
 	hio_read(buf, 1, 64, f);
 	strncpy(mod->name, buf, 63);	/* ensure string terminator */
+	mod->name[63] = '\0';
 	libxmp_set_type(m, "Galaxy Music System 5.0");
 	flags = hio_read8(f);	/* bit 0: Amiga period */
 	if (~flags & 0x01)

--- a/src/loaders/iff.c
+++ b/src/loaders/iff.c
@@ -170,7 +170,7 @@ int libxmp_iff_register(iff_handle opaque, const char *id,
 	if (f == NULL)
 		return -1;
 
-	strncpy(f->id, id, 4);
+	memcpy(f->id, id, 4);
 	f->loader = loader;
 
 	list_add_tail(&f->list, &data->iff_list);

--- a/src/loaders/imf_load.c
+++ b/src/loaders/imf_load.c
@@ -432,7 +432,8 @@ static int imf_load(struct module_data *m, HIO_HANDLE *f, const int start)
 		return -1;
 	}
 
-	strncpy((char *)xxi->name, ii.name, 24);
+	strncpy((char *)xxi->name, ii.name, 31);
+	xxi->name[31] = '\0';
 
 	for (j = 0; j < 108; j++) {
 		xxi->map[j + 12].ins = ii.map[j];

--- a/src/loaders/masi_load.c
+++ b/src/loaders/masi_load.c
@@ -130,9 +130,11 @@ static int get_titl(struct module_data *m, int size, HIO_HANDLE *f, void *parm)
 {
 	struct xmp_module *mod = &m->mod;
 	char buf[40];
-	
+
 	hio_read(buf, 1, 40, f);
-	strncpy(mod->name, buf, size > 32 ? 32 : size);
+	size = size > 32 ? 32 : size;
+	strncpy(mod->name, buf, size);
+	mod->name[size] = '\0';
 
 	return 0;
 }

--- a/src/loaders/mdl_load.c
+++ b/src/loaders/mdl_load.c
@@ -622,6 +622,7 @@ static int get_chunk_ii(struct module_data *m, int size, HIO_HANDLE *f, void *pa
 	hio_read(buf, 1, 32, f);
 	buf[32] = 0;
 	strncpy(xxi->name, buf, 31);
+	xxi->name[31] = '\0';
 
 	D_(D_INFO "[%2X] %-32.32s %2d", data->i_index[i], xxi->name, xxi->nsm);
 
@@ -709,6 +710,7 @@ static int get_chunk_is(struct module_data *m, int size, HIO_HANDLE *f, void *pa
 	hio_read(buf, 1, 32, f);
 	buf[32] = 0;
 	strncpy(xxs->name, buf, 31);
+	xxs->name[31] = '\0';
 
 	hio_seek(f, 8, SEEK_CUR);		/* Sample filename */
 
@@ -764,21 +766,23 @@ static int get_chunk_i0(struct module_data *m, int size, HIO_HANDLE *f, void *pa
 	return -1;
 
     for (i = 0; i < mod->ins; i++) {
+	struct xmp_instrument *xxi = &mod->xxi[i];
 	struct xmp_subinstrument *sub;
 	struct xmp_sample *xxs = &mod->xxs[i];
 	int c5spd;
 
-	mod->xxi[i].nsm = 1;
+	xxi->nsm = 1;
 	if (libxmp_alloc_subinstrument(mod, i, 1) < 0)
 	    return -1;
 
-	sub = &mod->xxi[i].sub[0];
+	sub = &xxi->sub[0];
 	sub->sid = data->i_index[i] = data->s_index[i] = hio_read8(f);
 
 	hio_read(buf, 1, 32, f);
 	buf[32] = 0;
 	hio_seek(f, 8, SEEK_CUR);	/* Sample filename */
-	strncpy(mod->xxi[i].name, buf, 31);
+	strncpy(xxi->name, buf, 31);
+	xxi->name[31] = '\0';
 
 	c5spd = hio_read16l(f);
 

--- a/src/loaders/med4_load.c
+++ b/src/loaders/med4_load.c
@@ -578,6 +578,7 @@ static int med4_load(struct module_data *m, HIO_HANDLE *f, const int start)
 		type = (int16)hio_read16b(f);	/* instrument type */
 
 		strncpy((char *)xxi->name, temp_inst[i].name, 32);
+		xxi->name[31] = '\0';
 
 		D_(D_INFO "\n[%2X] %-32.32s %d", i, xxi->name, type);
 

--- a/src/loaders/psm_load.c
+++ b/src/loaders/psm_load.c
@@ -57,13 +57,14 @@ static int psm_load(struct module_data *m, HIO_HANDLE *f, const int start)
 	uint32 p_ord, p_chn, p_pat, p_ins;
 	uint32 p_smp[64];
 	int type, ver /*, mode*/;
- 
+
 	LOAD_INIT();
 
 	hio_read32b(f);
 
 	hio_read(buf, 1, 60, f);
-	strncpy(mod->name, (char *)buf, 60);
+	memcpy(mod->name, (char *)buf, 59);
+	mod->name[59] = '\0';
 
 	type = hio_read8(f);		/* song type */
 	ver = hio_read8(f);		/* song version */
@@ -115,6 +116,7 @@ static int psm_load(struct module_data *m, HIO_HANDLE *f, const int start)
 
 	hio_seek(f, start + p_ins, SEEK_SET);
 	for (i = 0; i < mod->ins; i++) {
+		struct xmp_instrument *xxi = &mod->xxi[i];
 		uint16 flags, c2spd;
 		int finetune;
 
@@ -124,7 +126,8 @@ static int psm_load(struct module_data *m, HIO_HANDLE *f, const int start)
 		hio_read(buf, 1, 13, f);	/* sample filename */
 		hio_read(buf, 1, 24, f);	/* sample description */
 		buf[24] = 0;			/* add string termination */
-		strncpy((char *)mod->xxi[i].name, (char *)buf, 24);
+		strncpy(xxi->name, (char *)buf, 24);
+		xxi->name[24] = '\0';
 		p_smp[i] = hio_read32l(f);
 		hio_read32l(f);			/* memory location */
 		hio_read16l(f);			/* sample number */

--- a/src/loaders/rtm_load.c
+++ b/src/loaders/rtm_load.c
@@ -226,8 +226,9 @@ static int rtm_load(struct module_data *m, HIO_HANDLE *f, const int start)
 			return -1;
 		}
 	}
-	
-	strncpy(mod->name, oh.name, 20);
+
+	strncpy(mod->name, oh.name, 32);
+	mod->name[32] = '\0';
 	snprintf(mod->type, XMP_NAME_SIZE, "%s RTM %x.%02x",
 				tracker_name, version >> 8, version & 0xff);
 	/* strncpy(m->author, composer, XMP_NAME_SIZE); */

--- a/src/loaders/stm_load.c
+++ b/src/loaders/stm_load.c
@@ -271,7 +271,7 @@ static int stm_load(struct module_data *m, HIO_HANDLE * f, const int start)
 
 	for (i = 0; i < mod->ins; i++) {
 		if (sfh.ins[i].volume && sfh.ins[i].length) {
-			hio_seek(f, start + sfh.ins[i].rsvd1 << 4, SEEK_SET);
+			hio_seek(f, start + (sfh.ins[i].rsvd1 << 4), SEEK_SET);
 			if (libxmp_load_sample(m, f, 0, &mod->xxs[i], NULL) < 0)
 				return -1;
 		} else {


### PR DESCRIPTION
Fixes a bunch of annoying GCC 10(?) warnings caused by usage of strncpy. Some of the strncpy uses were legitimate but a few (like the Galaxy, PSM, and RTM loaders) were potentially cutting off terminating nulls.

Also fixes an operator precedence error from https://github.com/cmatsuoka/libxmp/pull/93 that GCC caught but somehow none of us noticed (sorry!).