### PR TITLE
Revert -Wstringop-truncation fix in libxmp_iff_register.

### DIFF
--- a/src/loaders/iff.c
+++ b/src/loaders/iff.c
@@ -170,7 +170,7 @@ int libxmp_iff_register(iff_handle opaque, const char *id,
 	if (f == NULL)
 		return -1;
 
-	memcpy(f->id, id, 4);
+	strncpy(f->id, id, 4);
 	f->loader = loader;
 
 	list_add_tail(&f->list, &data->iff_list);


### PR DESCRIPTION
Reverts a faulty warning fix from commit c7dccce6. This was the rare legitimate usage of strncpy and I didn't realize this function gets provided id strings shorter than 4 bytes (happens in the MDL loader...).