### PR TITLE
Fix Schism Tracker version date calculation.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -150,7 +150,7 @@ darwin*)
   LIBS="${old_LIBS}"
   ;;
 esac
-AC_CHECK_FUNCS(popen mkstemp fnmatch umask localtime_r round powf)
+AC_CHECK_FUNCS(popen mkstemp fnmatch umask round powf)
 
 AC_CONFIG_FILES([Makefile])
 AC_CONFIG_FILES([libxmp.pc])

--- a/lite/configure.ac
+++ b/lite/configure.ac
@@ -149,7 +149,7 @@ darwin*)
   LIBS="${old_LIBS}"
   ;;
 esac
-AC_CHECK_FUNCS(localtime_r round powf)
+AC_CHECK_FUNCS(round powf)
 
 AC_CONFIG_FILES([Makefile])
 AC_CONFIG_FILES([libxmp-lite.pc])

--- a/src/loaders/loader.h
+++ b/src/loaders/loader.h
@@ -47,6 +47,7 @@ void	libxmp_get_instrument_path	(struct module_data *, char *, int);
 void	libxmp_set_type			(struct module_data *, const char *, ...);
 int	libxmp_load_sample		(struct module_data *, HIO_HANDLE *, int,
 					 struct xmp_sample *, const void *);
+void	libxmp_schism_tracker_string	(char *, size_t, int, int);
 
 extern uint8		libxmp_ord_xlat[];
 extern const int	libxmp_arch_vol_table[];

--- a/src/loaders/s3m_load.c
+++ b/src/loaders/s3m_load.c
@@ -271,7 +271,7 @@ static int s3m_load(struct module_data *m, HIO_HANDLE * f, const int start)
 	sfh.mv = buf[51];			/* Master volume */
 	sfh.uc = buf[52];			/* Ultra click removal */
 	sfh.dp = buf[53];			/* Default pan positions if 0xfc */
-	/* 54-61 reserved */
+	memcpy(sfh.rsvd2, buf + 54, 8);		/* Reserved */
 	sfh.special = readmem16l(buf + 62);	/* Ptr to special custom data */
 	memcpy(sfh.chset, buf + 64, 32);	/* Channel settings */
 
@@ -418,9 +418,8 @@ static int s3m_load(struct module_data *m, HIO_HANDLE * f, const int start)
 		break;
 	case 4:
 		if (sfh.version != 0x4100) {
-			snprintf(tracker_name, 40, "Schism Tracker %d.%02x",
-				 (sfh.version & 0x0f00) >> 8,
-				 sfh.version & 0xff);
+			libxmp_schism_tracker_string(tracker_name, 40,
+				(sfh.version & 0x0fff), sfh.rsvd2[0] | (sfh.rsvd2[1] << 8));
 			break;
 		}
 		/* fall through */


### PR DESCRIPTION
Fixes several issues with the calculation of Schism Tracker dates.

* The date calculation was using a UTC epoch time but calculating the version date with localtime_r instead of gmtime_r (maybe because Schism uses localtime_r... the difference is Schism generates its epoch time with mktime).
* The UTC epoch time was wrong (2009-10-01 instead of 2009-10-31).
* The S3M loader was not calculating Schism Tracker dates at all.
* Added detection for extended Schism Tracker dates (>2020-10-28) to both the S3M and IT loaders.

Fixes #154. I think I got this right, but this should *really* be reviewed by @sagamusix before it's merged.

edit: this sure doubles the number of spurious format truncation warnings for Schism Tracker dates though. 🙄