### PR TITLE
Change return type of xmp_get_format_list to const char *const *.

### DIFF
--- a/docs/libxmp.rst
+++ b/docs/libxmp.rst
@@ -233,7 +233,7 @@ const unsigned int xmp_vercode
 
 .. _xmp_get_format_list():
 
-char \*\*xmp_get_format_list()
+const char \*const \*xmp_get_format_list()
 ``````````````````````````````
 
   Query the list of supported module formats.

--- a/include/xmp.h
+++ b/include/xmp.h
@@ -329,7 +329,7 @@ LIBXMP_EXPORT void        xmp_get_frame_info  (xmp_context, struct xmp_frame_inf
 LIBXMP_EXPORT void        xmp_end_player      (xmp_context);
 LIBXMP_EXPORT void        xmp_inject_event    (xmp_context, int, struct xmp_event *);
 LIBXMP_EXPORT void        xmp_get_module_info (xmp_context, struct xmp_module_info *);
-LIBXMP_EXPORT char      **xmp_get_format_list (void);
+LIBXMP_EXPORT const char *const *xmp_get_format_list (void);
 LIBXMP_EXPORT int         xmp_next_position   (xmp_context);
 LIBXMP_EXPORT int         xmp_prev_position   (xmp_context);
 LIBXMP_EXPORT int         xmp_set_position    (xmp_context, int);

--- a/src/control.c
+++ b/src/control.c
@@ -529,7 +529,7 @@ int xmp_get_player__(xmp_context opaque, int parm)
 	return ret;
 }
 
-char **xmp_get_format_list()
+const char *const *xmp_get_format_list()
 {
 	return format_list();
 }

--- a/src/format.c
+++ b/src/format.c
@@ -158,7 +158,7 @@ const struct format_loader *const format_loader[NUM_FORMATS + 2] = {
 
 static const char *_farray[NUM_FORMATS + NUM_PW_FORMATS + 1] = { NULL };
 
-char **format_list()
+const char *const *format_list()
 {
 	int count, i;
 
@@ -179,5 +179,5 @@ char **format_list()
 		_farray[count] = NULL;
 	}
 
-	return (char **)_farray;
+	return _farray;
 }

--- a/src/format.h
+++ b/src/format.h
@@ -11,7 +11,7 @@ struct format_loader {
 	int (*const loader)(struct module_data *, HIO_HANDLE *, const int);
 };
 
-char **format_list(void);
+const char *const *format_list(void);
 
 #ifndef LIBXMP_CORE_PLAYER
 

--- a/test-dev/test_api_get_format_list.c
+++ b/test-dev/test_api_get_format_list.c
@@ -2,7 +2,7 @@
 
 TEST(test_api_get_format_list)
 {
-	char **list;
+	const char *const *list;
 	int i;
 
 	list = xmp_get_format_list();


### PR DESCRIPTION
This function returns a static array of `const char *` pointers to static data, but `format_list()` and `xmp_get_format_list()` both return this array as a `char **`, which doesn't really communicate that none of this data should be modified/freed. Not sure if this should actually be merged right now (it may be a breaking API change), but I think it should be addressed at some point.

Fixes #192.