### PR TITLE
Increase maximum IFF chunk size to 8 MiB.

### DIFF
--- a/src/loaders/iff.h
+++ b/src/loaders/iff.h
@@ -13,7 +13,7 @@
 #define IFF_SKIP_EMBEDDED	0x10
 #define IFF_CHUNK_TRUNC4	0x20
 
-#define IFF_MAX_CHUNK_SIZE	0x400000
+#define IFF_MAX_CHUNK_SIZE	0x800000
 
 typedef void *iff_handle;
 


### PR DESCRIPTION
This fixes the loading of several DigiBooster Pro modules with sample chunks larger than 4 MiB, of which I found >=22 in the ModLand collection. Fixes #166. 