### PR TITLE
Replace fixed memset sizes with sizeof() in various loaders.

### DIFF
--- a/src/loaders/digi_load.c
+++ b/src/loaders/digi_load.c
@@ -191,7 +191,7 @@ static int digi_load(struct module_data *m, HIO_HANDLE *f, const int start)
 	    hio_read (chn_table, 1, 64, f);
 	} else {
 	    w = 64 * mod->chn;
-	    memset (chn_table, 0xff, 64);
+	    memset(chn_table, 0xff, sizeof(chn_table));
 	}
 
 	for (j = 0; j < 64; j++) {

--- a/src/loaders/emod_load.c
+++ b/src/loaders/emod_load.c
@@ -116,7 +116,7 @@ static int get_emic(struct module_data *m, int size, HIO_HANDLE * f, void *parm)
 	if (libxmp_init_pattern(mod) < 0)
 		return -1;
 
-	memset(reorder, 0, 256);
+	memset(reorder, 0, sizeof(reorder));
 
 	for (i = 0; i < mod->pat; i++) {
 		reorder[hio_read8(f)] = i;

--- a/src/loaders/it_load.c
+++ b/src/loaders/it_load.c
@@ -891,7 +891,7 @@ static int load_it_pattern(struct module_data *m, int i, int new_fx,
 
 	r = 0;
 
-	memset(last_fxp, 0, 64);
+	memset(last_fxp, 0, sizeof(last_fxp));
 	memset(lastevent, 0, L_CHANNELS * sizeof(struct xmp_event));
 	memset(&dummy, 0, sizeof(struct xmp_event));
 

--- a/src/loaders/mod_load.c
+++ b/src/loaders/mod_load.c
@@ -431,7 +431,7 @@ static int mod_load(struct module_data *m, HIO_HANDLE *f, const int start)
     mh.len = hio_read8(f);
     mh.restart = hio_read8(f);
     hio_read(mh.order, 128, 1, f);
-    memset(magic, 0, 8);
+    memset(magic, 0, sizeof(magic));
     hio_read(magic, 1, 4, f);
     if (hio_error(f)) {
         return -1;

--- a/src/loaders/prowizard/ac1d.c
+++ b/src/loaders/prowizard/ac1d.c
@@ -30,8 +30,8 @@ static int depack_ac1d(HIO_HANDLE *in, FILE *out)
 	/*int tsize1, tsize2, tsize3;*/
 	int i, j, k;
 
-	memset(paddr, 0, 128 * 4);
-	memset(psize, 0, 128 * 4);
+	memset(paddr, 0, sizeof(paddr));
+	memset(psize, 0, sizeof(psize));
 
 	npos = hio_read8(in);
 	ntk_byte = hio_read8(in);
@@ -80,7 +80,7 @@ static int depack_ac1d(HIO_HANDLE *in, FILE *out)
 		/*tsize2 =*/ hio_read32b(in);
 		/*tsize3 =*/ hio_read32b(in);
 
-		memset(tmp, 0, 1024);
+		memset(tmp, 0, sizeof(tmp));
 		for (k = 0; k < 4; k++) {
 			for (j = 0; j < 64; j++) {
 				int x = j * 16 + k * 4;

--- a/src/loaders/prowizard/di.c
+++ b/src/loaders/prowizard/di.c
@@ -48,8 +48,8 @@ static int depack_di(HIO_HANDLE *in, FILE *out)
 	int size, ssize;
 	int pos;
 
-	memset(ptable, 0, 128);
-	memset(paddr, 0, 256);
+	memset(ptable, 0, sizeof(ptable));
+	memset(paddr, 0, sizeof(paddr));
 
 	pw_write_zero(out, 20);			/* title */
 
@@ -74,7 +74,7 @@ static int depack_di(HIO_HANDLE *in, FILE *out)
 		write16b(out, hio_read16b(in));		/* loop size */
 	}
 
-	memset(tmp, 0, 50);
+	memset(tmp, 0, sizeof(tmp));
 	for (i = nins; i < 31; i++) {
 		fwrite(tmp, 30, 1, out);
 	}

--- a/src/loaders/prowizard/eureka.c
+++ b/src/loaders/prowizard/eureka.c
@@ -47,7 +47,7 @@ static int depack_eu(HIO_HANDLE *in, FILE *out)
 
 	/* the track data now ... */
 	for (i = 0; i < npat; i++) {
-		memset(tmp, 0, 1024);
+		memset(tmp, 0, sizeof(tmp));
 		for (j = 0; j < 4; j++) {
 			hio_seek(in, trk_addr[i][j], SEEK_SET);
 			for (k = 0; k < 64; k++) {

--- a/src/loaders/prowizard/fc-m.c
+++ b/src/loaders/prowizard/fc-m.c
@@ -20,7 +20,7 @@ static int depack_fcm(HIO_HANDLE *in, FILE *out)
 	int i;
 	int size, ssize = 0;
 
-	memset(ptable, 0, 128);
+	memset(ptable, 0, sizeof(ptable));
 
 	hio_read32b(in);				/* bypass "FC-M" ID */
 	hio_read16b(in);				/* version number? */

--- a/src/loaders/prowizard/fuchs.c
+++ b/src/loaders/prowizard/fuchs.c
@@ -22,9 +22,9 @@ static int depack_fuchs(HIO_HANDLE *in, FILE *out)
 	unsigned pat_size;
 	unsigned i;
 
-	memset(smp_len, 0, 16 * 4);
-	memset(loop_start, 0, 16 * 4);
-	memset(data, 0, 1080);
+	memset(smp_len, 0, sizeof(smp_len));
+	memset(loop_start, 0, sizeof(loop_start));
+	memset(data, 0, sizeof(data));
 
 	hio_read(data, 1, 10, in);		/* read/write title */
 	/*ssize =*/ hio_read32b(in);		/* read all sample data size */

--- a/src/loaders/prowizard/fuzzac.c
+++ b/src/loaders/prowizard/fuzzac.c
@@ -33,9 +33,9 @@ static int depack_fuzz(HIO_HANDLE *in, FILE *out)
 	int lps, lsz;
 	int i, j, k, l;
 
-	memset(tidx, 0, 128 * 16);
-	memset(tidx_real, 0, 128 * 4);
-	memset(ord, 0, 128);
+	memset(tidx, 0, sizeof(tidx));
+	memset(tidx_real, 0, sizeof(tidx_real));
+	memset(ord, 0, sizeof(ord));
 
 	hio_read32b(in);			/* bypass ID */
 	hio_read16b(in);			/* bypass 2 unknown bytes */
@@ -140,8 +140,8 @@ static int depack_fuzz(HIO_HANDLE *in, FILE *out)
 	l = 2118 + len * 16;
 
 	for (i = 0; i < npat; i++) {
-		memset(data, 0, 1024);
-		memset(track, 0, 4 << 8);
+		memset(data, 0, sizeof(data));
+		memset(track, 0, sizeof(track));
 
 		hio_seek(in, l + (tidx_real[i][0] << 8), SEEK_SET);
 		hio_read(track[0], 256, 1, in);

--- a/src/loaders/prowizard/gmc.c
+++ b/src/loaders/prowizard/gmc.c
@@ -21,7 +21,7 @@ static int depack_GMC(HIO_HANDLE *in, FILE *out)
 	long ssize = 0;
 	long i = 0, j = 0;
 
-	memset(ptable, 0, 128);
+	memset(ptable, 0, sizeof(ptable));
 
 	pw_write_zero(out, 20);			/* title */
 
@@ -69,7 +69,7 @@ static int depack_GMC(HIO_HANDLE *in, FILE *out)
 	/* pattern data */
 	hio_seek(in, 444, SEEK_SET);
 	for (i = 0; i <= max; i++) {
-		memset(tmp, 0, 1024);
+		memset(tmp, 0, sizeof(tmp));
 		hio_read(tmp, 1024, 1, in);
 		for (j = 0; j < 256; j++) {
 			switch (tmp[(j * 4) + 2] & 0x0f) {

--- a/src/loaders/prowizard/heatseek.c
+++ b/src/loaders/prowizard/heatseek.c
@@ -23,8 +23,8 @@ static int depack_crb(HIO_HANDLE *in, FILE *out)
 	int i, j, k, l, m;
 	int size, ssize = 0;
 
-	memset(ptable, 0, 128);
-	memset(taddr, 0, 512 * 4);
+	memset(ptable, 0, sizeof(ptable));
+	memset(taddr, 0, sizeof(taddr));
 
 	pw_write_zero(out, 20);				/* write title */
 
@@ -56,7 +56,7 @@ static int depack_crb(HIO_HANDLE *in, FILE *out)
 
 	/* pattern data */
 	for (i = 0; i < pat_max; i++) {
-		memset(pat, 0, 1024);
+		memset(pat, 0, sizeof(pat));
 		for (j = 0; j < 4; j++) {
 			int x = hio_tell(in);
 			if (x < 0) {

--- a/src/loaders/prowizard/hrt.c
+++ b/src/loaders/prowizard/hrt.c
@@ -17,7 +17,7 @@ static int depack_hrt(HIO_HANDLE *in, FILE *out)
 	int ssize = 0;
 	int i, j;
 
-	memset(buf, 0, 950);
+	memset(buf, 0, sizeof(buf));
 
 	hio_read(buf, 950, 1, in);			/* read header */
 	for (i = 0; i < 31; i++)		/* erase addresses */

--- a/src/loaders/prowizard/kris.c
+++ b/src/loaders/prowizard/kris.c
@@ -23,10 +23,10 @@ static int depack_kris(HIO_HANDLE *in, FILE *out)
 	int i, j, k;
 	int size, ssize = 0;
 
-	memset(tmp, 0, 1024);
-	memset(ptable, 0, 128);
-	memset(taddr, 0, 128 * 4 * 2);
-	memset(tdata, 0, 512 << 8);
+	memset(tmp, 0, sizeof(tmp));
+	memset(ptable, 0, sizeof(ptable));
+	memset(taddr, 0, sizeof(taddr));
+	memset(tdata, 0, sizeof(tdata));
 
 	pw_move_data(out, in, 20);			/* title */
 	hio_seek(in, 2, SEEK_CUR);
@@ -81,7 +81,7 @@ static int depack_kris(HIO_HANDLE *in, FILE *out)
 
 	/* Track data ... */
 	for (i = 0; i <= (maxtaddr / 256); i += 1) {
-		memset(tmp, 0, 1024);
+		memset(tmp, 0, sizeof(tmp));
 		hio_read(tmp, 256, 1, in);
 
 		for (j = 0; j < 64 * 4; j += 4) {
@@ -102,7 +102,7 @@ static int depack_kris(HIO_HANDLE *in, FILE *out)
 	}
 
 	for (i = 0; i <= max; i++) {
-		memset(tmp, 0, 1024);
+		memset(tmp, 0, sizeof(tmp));
 		for (j = 0; j < 64 * 4; j += 4) {
 			uint8 *p = &tmp[j * 4];
 

--- a/src/loaders/prowizard/ksm.c
+++ b/src/loaders/prowizard/ksm.c
@@ -25,9 +25,9 @@ static int depack_ksm(HIO_HANDLE *in, FILE *out)
 	int ssize = 0;
 	int i, j, k;
 
-	memset(plist, 0, 128);
-	memset(trknum, 0, 128 * 4);
-	memset(real_tnum, 0, 128 * 4);
+	memset(plist, 0, sizeof(plist));
+	memset(trknum, 0, sizeof(trknum));
+	memset(real_tnum, 0, sizeof(real_tnum));
 
 	/* title */
 	hio_seek(in, 2, SEEK_SET);
@@ -141,8 +141,8 @@ static int depack_ksm(HIO_HANDLE *in, FILE *out)
 
 	/* pattern data */
 	for (i = 0; i < c5; i++) {
-		memset(tmp, 0, 1024);
-		memset(tdata, 0, 192 * 4);
+		memset(tmp, 0, sizeof(tmp));
+		memset(tdata, 0, sizeof(tdata));
 
 		for (k = 0; k < 4; k++) {
 			hio_seek(in, 1536 + 192 * real_tnum[i][k], SEEK_SET);

--- a/src/loaders/prowizard/mp.c
+++ b/src/loaders/prowizard/mp.c
@@ -21,7 +21,7 @@ static int depack_mp(HIO_HANDLE *in, FILE *out)
 	int i;
 	int size, ssize = 0;
 
-	memset(ptable, 0, 128);
+	memset(ptable, 0, sizeof(ptable));
 
 	pw_write_zero(out, 20);				/* title */
 

--- a/src/loaders/prowizard/noiserun.c
+++ b/src/loaders/prowizard/noiserun.c
@@ -78,7 +78,7 @@ static int depack_nru(HIO_HANDLE *in, FILE *out)
 	/* pattern data */
 	hio_seek(in, 0x043c, SEEK_SET);
 	for (i = 0; i < max_pat; i++) {
-		memset(pat_data, 0, 1025);
+		memset(pat_data, 0, sizeof(pat_data));
 		hio_read(tmp, 1024, 1, in);
 		for (j = 0; j < 256; j++) {
 			ins = (tmp[j * 4 + 3] >> 3) & 0x1f;

--- a/src/loaders/prowizard/novotrade.c
+++ b/src/loaders/prowizard/novotrade.c
@@ -28,7 +28,7 @@ static int depack_ntp(HIO_HANDLE *in, FILE *out)
 	npat = hio_read16b(in);			/* number of patterns stored */
 	smp_addr = hio_read16b(in) + body_addr + 4;	/* get 'SAMP' address */
 
-	memset(buf, 0, 930);
+	memset(buf, 0, sizeof(buf));
 
 	/* instruments */
 	for (i = 0; i < nins; i++) {
@@ -67,7 +67,7 @@ static int depack_ntp(HIO_HANDLE *in, FILE *out)
 
 	/* pattern addresses now */
 	/* Where is on it */
-	memset(pat_addr, 0, 256);
+	memset(pat_addr, 0, sizeof(pat_addr));
 	for (i = 0; i < npat; i++)
 		pat_addr[i] = hio_read16b(in);
 
@@ -76,7 +76,7 @@ static int depack_ntp(HIO_HANDLE *in, FILE *out)
 	/* pattern data now ... *gee* */
 	for (i = 0; i < npat; i++) {
 		hio_seek(in, body_addr + 4 + pat_addr[i], SEEK_SET);
-		memset(buf, 0, 1024);
+		memset(buf, 0, sizeof(buf));
 
 		for (j = 0; j < 64; j++) {
 			int x = hio_read16b(in);

--- a/src/loaders/prowizard/np1.c
+++ b/src/loaders/prowizard/np1.c
@@ -24,8 +24,8 @@ static int depack_np1(HIO_HANDLE *in, FILE *out)
 	int i, j, k;
 	int trk_start;
 
-	memset(ptable, 0, 128);
-	memset(trk_addr, 0, 128 * 4 * 4);
+	memset(ptable, 0, sizeof(ptable));
+	memset(trk_addr, 0, sizeof(trk_addr));
 
 	c1 = hio_read8(in);			/* read number of samples */
 	c2 = hio_read8(in);
@@ -98,7 +98,7 @@ static int depack_np1(HIO_HANDLE *in, FILE *out)
 
 	/* the track data now ... */
 	for (i = 0; i < npat; i++) {
-		memset(tmp, 0, 1024);
+		memset(tmp, 0, sizeof(tmp));
 		for (j = 0; j < 4; j++) {
 			hio_seek(in, trk_start + trk_addr[i][3 - j], SEEK_SET);
 			for (k = 0; k < 64; k++) {

--- a/src/loaders/prowizard/np2.c
+++ b/src/loaders/prowizard/np2.c
@@ -24,8 +24,8 @@ static int depack_np2(HIO_HANDLE *in, FILE *out)
 	int i, j, k;
 	int trk_start;
 
-	memset(ptable, 0, 128);
-	memset(trk_addr, 0, 128 * 4 * 4);
+	memset(ptable, 0, sizeof(ptable));
+	memset(trk_addr, 0, sizeof(trk_addr));
 
 	c1 = hio_read8(in);			/* read number of samples */
 	c2 = hio_read8(in);
@@ -102,7 +102,7 @@ static int depack_np2(HIO_HANDLE *in, FILE *out)
 
 	/* the track data now ... */
 	for (i = 0; i < npat; i++) {
-		memset(tmp, 0, 1024);
+		memset(tmp, 0, sizeof(tmp));
 		for (j = 0; j < 4; j++) {
 			hio_seek(in, trk_start + trk_addr[i][3 - j], SEEK_SET);
 			for (k = 0; k < 64; k++) {

--- a/src/loaders/prowizard/np3.c
+++ b/src/loaders/prowizard/np3.c
@@ -27,8 +27,8 @@ static int depack_np3(HIO_HANDLE *in, FILE *out)
 	int i, j, k;
 	int trk_start;
 
-	memset(ptable, 0, 128);
-	memset(trk_addr, 0, 128 * 4 * 4);
+	memset(ptable, 0, sizeof(ptable));
+	memset(trk_addr, 0, sizeof(trk_addr));
 
 	c1 = hio_read8(in);			/* read number of samples */
 	c2 = hio_read8(in);
@@ -95,7 +95,7 @@ static int depack_np3(HIO_HANDLE *in, FILE *out)
 	/* the track data now ... */
 	smp_addr = 0;
 	for (i = 0; i < npat; i++) {
-		memset(tmp, 0, 1024);
+		memset(tmp, 0, sizeof(tmp));
 		for (j = 0; j < 4; j++) {
 			int x;
 

--- a/src/loaders/prowizard/p40.c
+++ b/src/loaders/prowizard/p40.c
@@ -40,10 +40,10 @@ static int depack_p4x(HIO_HANDLE *in, FILE *out)
 	struct smp ins;
 	uint32 id;
 
-	memset(track_addr, 0, 128 * 4 * 2);
-	memset(tr, 0, 512 << 8);
-	memset(SampleAddress, 0, 31 * 4);
-	memset(SampleSize, 0, 31 * 4);
+	memset(track_addr, 0, sizeof(track_addr));
+	memset(tr, 0, sizeof(tr));
+	memset(SampleAddress, 0, sizeof(SampleAddress));
+	memset(SampleSize, 0, sizeof(SampleSize));
 
 	id = hio_read32b(in);
 #if 0
@@ -151,7 +151,6 @@ static int depack_p4x(HIO_HANDLE *in, FILE *out)
 				if (c1 != 0x80) {
 					sample = ((c1 << 4) & 0x10) |
 							((c2 >> 4) & 0x0f);
-					memset(note, 0, 2);
 					mynote = c1 & 0x7f;
 					note[0] = ptk_table[mynote / 2][0];
 					note[1] = ptk_table[mynote / 2][1];
@@ -211,7 +210,6 @@ static int depack_p4x(HIO_HANDLE *in, FILE *out)
 
 					sample = ((c1 << 4) & 0x10) |
 						((c2 >> 4) & 0x0f);
-					memset(note, 0, 2);
 					mynote = c1 & 0x7f;
 					note[0] = ptk_table[mynote / 2][0];
 					note[1] = ptk_table[mynote / 2][1];
@@ -260,7 +258,7 @@ static int depack_p4x(HIO_HANDLE *in, FILE *out)
 
 	/* write pattern data */
 	for (i = 0; i < len; i++) {
-		memset(tmp, 0, 1024);
+		memset(tmp, 0, sizeof(tmp));
 		for (j = 0; j < 64; j++) {
 			for (k = 0; k < 4; k++) {
 				int x = j * 16 + k * 4;

--- a/src/loaders/prowizard/p61a.c
+++ b/src/loaders/prowizard/p61a.c
@@ -42,11 +42,11 @@ static int depack_p61a(HIO_HANDLE *in, FILE *out)
     int Unpacked_Sample_Data_Size;
     int x;
 
-    memset(taddr, 0, 128 * 4 * 4);
-    memset(tdata, 0, 512 << 8);
-    memset(ptable, 0, 128);
-    memset(smp_size, 0, 31 * 4);
-    memset(isize, 0, 31 * 2);
+    memset(taddr, 0, sizeof(taddr));
+    memset(tdata, 0, sizeof(tdata));
+    memset(ptable, 0, sizeof(ptable));
+    memset(smp_size, 0, sizeof(smp_size));
+    memset(isize, 0, sizeof(isize));
     for (i = 0; i < 31; i++) {
 	PACK[i] = 0;
 	/* DELTA[i] = 0;*/
@@ -484,7 +484,7 @@ static int depack_p61a(HIO_HANDLE *in, FILE *out)
     /* write pattern data */
 
     for (i = 0; i < npat; i++) {
-	memset(tmp, 0, 1024);
+	memset(tmp, 0, sizeof(tmp));
 	for (j = 0; j < 64; j++) {
 	    for (k = 0; k < 4; k++)
 		memcpy(&tmp[j * 16 + k * 4], &tdata[k + i * 4][j * 4], 4);

--- a/src/loaders/prowizard/pha.c
+++ b/src/loaders/prowizard/pha.c
@@ -34,13 +34,13 @@ static int depack_pha(HIO_HANDLE *in, FILE *out)
 	int smp_addr;
 	short ocpt[4];
 
-	memset(paddr, 0, 128 * 4);
-	memset(paddr1, 0, 128 * 4);
-	memset(paddr2, 0, 128 * 4);
-	memset(pnum, 0, 128);
-	memset(pnum1, 0, 128);
-	memset(onote, 0, 4 * 4);
-	memset(ocpt, 0, 4 * 2);
+	memset(paddr, 0, sizeof(paddr));
+	memset(paddr1, 0, sizeof(paddr1));
+	memset(paddr2, 0, sizeof(paddr2));
+	memset(pnum, 0, sizeof(pnum));
+	memset(pnum1, 0, sizeof(pnum1));
+	memset(onote, 0, sizeof(onote));
+	memset(ocpt, 0, sizeof(ocpt));
 
 	pw_write_zero(out, 20);				/* title */
 
@@ -127,7 +127,7 @@ restart:
 	}
 
 	/* try to take care of unused patterns ... HARRRRRRD */
-	memset(paddr1, 0, 128 * 4);
+	memset(paddr1, 0, sizeof(paddr1));
 	j = 0;
 	k = paddr[0];
 	/* 120 ... leaves 8 unused ptk_tableible patterns .. */
@@ -148,7 +148,7 @@ restart:
 		}
 	}
 
-	memset(pnum, 0, 128);
+	memset(pnum, 0, sizeof(pnum));
 	pat_addr = 999999l;
 	for (i = 0; i < 128; i++) {
 		pnum[i] = pnum1[i];

--- a/src/loaders/prowizard/pm.c
+++ b/src/loaders/prowizard/pm.c
@@ -24,8 +24,8 @@ void Depack_PM (FILE * in, FILE * out)
 	if (Save_Status == BAD)
 		return;
 
-	memset(Header, 0, 2048);
-	memset(ptable, 0, 128);
+	memset(Header, 0, sizeof(Header));
+	memset(ptable, 0, sizeof(ptable));
 
 	// in = fdopen (fd_in, "rb");
 	// sprintf ( Depacked_OutName , "%ld.mod" , Cpt_Filename-1 );
@@ -48,7 +48,7 @@ void Depack_PM (FILE * in, FILE * out)
 	fwrite (&npat, 1, 1, out);
 	/*printf ( "Size of pattern list : %d\n" , npat ); */
 
-	memset(Header, 0, 2048);
+	memset(Header, 0, sizeof(Header));
 
 	/* read and write ntk byte and pattern list */
 	fread (Header, 129, 1, in);

--- a/src/loaders/prowizard/pm01.c
+++ b/src/loaders/prowizard/pm01.c
@@ -24,10 +24,10 @@ static int depack_pm01(HIO_HANDLE *in, FILE *out)
 	int psize, size, ssize = 0;
 	int pat_ofs[128];
 
-	memset(ptable, 0, 128);
-	memset(pat_ofs, 0, 128 * 4);
-	memset(fin, 0, 31);
-	memset(oldins, 0, 4);
+	memset(ptable, 0, sizeof(ptable));
+	memset(pat_ofs, 0, sizeof(pat_ofs));
+	memset(fin, 0, sizeof(fin));
+	memset(oldins, 0, sizeof(oldins));
 
 	pw_write_zero(out, 20);			/* title */
 
@@ -83,7 +83,7 @@ static int depack_pm01(HIO_HANDLE *in, FILE *out)
 
 	/* read and XOR pattern data */
 	for (i = 0; i < npat; i++) {
-		memset(pdata, 0, 1024);
+		memset(pdata, 0, sizeof(pdata));
 		if (hio_read(pdata, 1, 1024, in) != 1024) {
 			return -1;
 		}

--- a/src/loaders/prowizard/pm10c.c
+++ b/src/loaders/prowizard/pm10c.c
@@ -33,14 +33,14 @@ static int depack_p10c(HIO_HANDLE *in, FILE *out)
 	uint8 fin[31];
 	uint8 oldins[4];
 
-	memset(pnum, 0, 128);
-	memset(pnum1, 0, 128);
-	memset(pptr, 0, 64 << 8);
-	memset(pat, 0, 128 * 1024);
-	memset(fin, 0, 31);
-	memset(oldins, 0, 4);
-	memset(paddr, 0, 128 * 4);
-	memset(paddr1, 0, 128 * 4);
+	memset(pnum, 0, sizeof(pnum));
+	memset(pnum1, 0, sizeof(pnum1));
+	memset(pptr, 0, sizeof(pptr));
+	memset(pat, 0, sizeof(pat));
+	memset(fin, 0, sizeof(fin));
+	memset(oldins, 0, sizeof(oldins));
+	memset(paddr, 0, sizeof(paddr));
+	memset(paddr1, 0, sizeof(paddr1));
 
 	for (i = 0; i < 128; i++)
 		paddr2[i] = 9999L;

--- a/src/loaders/prowizard/pm18a.c
+++ b/src/loaders/prowizard/pm18a.c
@@ -31,12 +31,12 @@ static int depack_p18a(HIO_HANDLE *in, FILE *out)
 	uint8 fin[31];
 	uint8 oldins[4];
 
-	memset(pnum, 0, 128);
-	memset(pptr, 0, 64 << 8);
-	memset(pat, 0, 128 * 1024);
-	memset(fin, 0, 31);
-	memset(oldins, 0, 4);
-	memset(paddr, 0, 128 * 4);
+	memset(pnum, 0, sizeof(pnum));
+	memset(pptr, 0, sizeof(pptr));
+	memset(pat, 0, sizeof(pat));
+	memset(fin, 0, sizeof(fin));
+	memset(oldins, 0, sizeof(oldins));
+	memset(paddr, 0, sizeof(paddr));
 
 	pw_write_zero(out, 20);				/* title */
 

--- a/src/loaders/prowizard/pm20.c
+++ b/src/loaders/prowizard/pm20.c
@@ -50,12 +50,12 @@ void Depack_PM20 (FILE * in, FILE * out)
 	// sprintf ( Depacked_OutName , "%ld.mod" , Cpt_Filename-1 );
 	// out = fdopen (fd_out, "w+b");
 
-	memset(pnum, 0, 128);
-	memset(pnum_tmp, 0, 128);
-	memset(pptr, 0, 64 << 8);
-	memset(Pattern, 0, 128 * 1024);
-	memset(paddr, 0, 128 * 4);
-	memset(paddr_tmp, 0, 128 * 4);
+	memset(pnum, 0, sizeof(pnum));
+	memset(pnum_tmp, 0, sizeof(pnum_tmp));
+	memset(pptr, 0, sizeof(pptr));
+	memset(Pattern, 0, sizeof(Pattern));
+	memset(paddr, 0, sizeof(paddr));
+	memset(paddr_tmp, 0, sizeof(paddr_tmp));
 	for (i = 0; i < 128; i++)
 		paddr_tmp2[i] = 9999l;
 

--- a/src/loaders/prowizard/pm40.c
+++ b/src/loaders/prowizard/pm40.c
@@ -49,12 +49,12 @@ void Depack_PM40 (FILE * in, FILE * out)
 	// sprintf ( Depacked_OutName , "%ld.mod" , Cpt_Filename-1 );
 	// out = fdopen (fd_out, "w+b");
 
-	memset(pnum, 0, 128);
-	memset(pnum_tmp, 0, 128);
-	memset(pptr, 0, 64 << 8);
-	memset(Pattern, 0, 128 * 1024);
-	memset(paddr, 0, 128 * 4);
-	memset(paddr_tmp, 0, 128 * 4);
+	memset(pnum, 0, sizeof(pnum));
+	memset(pnum_tmp, 0, sizeof(pnum_tmp));
+	memset(pptr, 0, sizeof(pptr));
+	memset(Pattern, 0, sizeof(Pattern));
+	memset(paddr, 0, sizeof(paddr));
+	memset(paddr_tmp, 0, sizeof(paddr_tmp));
 	for (i = 0; i < 128; i++)
 		paddr_tmp2[i] = 9999l;
 

--- a/src/loaders/prowizard/pp10.c
+++ b/src/loaders/prowizard/pp10.c
@@ -20,7 +20,7 @@ static int depack_pp10(HIO_HANDLE *in, FILE *out)
 	int i, j, k;
 	int ntrk, size, ssize = 0;
 
-	memset(trk_num, 0, 128 * 4);
+	memset(trk_num, 0, sizeof(trk_num));
 
 	pw_write_zero(out, 20);				/* write title */
 
@@ -70,7 +70,7 @@ static int depack_pp10(HIO_HANDLE *in, FILE *out)
 
 	/* track/pattern data */
 	for (i = 0; i < len; i++) {
-		memset(pdata, 0, 1024);
+		memset(pdata, 0, sizeof(pdata));
 		for (j = 0; j < 4; j++) {
 			hio_seek(in, 762 + (trk_num[j][i] << 8), SEEK_SET);
 			for (k = 0; k < 64; k++) {

--- a/src/loaders/prowizard/pp21.c
+++ b/src/loaders/prowizard/pp21.c
@@ -31,9 +31,9 @@ static int depack_pp21_pp30(HIO_HANDLE *in, FILE *out, int is_30)
 	int ssize;
 	int tabsize;		/* Reference Table Size */
 
-	memset(ptable, 0, 128);
-	memset(trk, 0, 4 * 128);
-	memset(tptr, 0, 512 * 64 * sizeof (int));
+	memset(ptable, 0, sizeof(ptable));
+	memset(trk, 0, sizeof(trk));
+	memset(tptr, 0, sizeof(tptr));
 
 	pw_write_zero(out, 20);			/* title */
 
@@ -97,7 +97,7 @@ static int depack_pp21_pp30(HIO_HANDLE *in, FILE *out, int is_30)
 	hio_read(tab, tabsize, 1, in);
 
 	for (i = 0; i < numpat; i++) {
-		memset(buf, 0, 1024);
+		memset(buf, 0, sizeof(buf));
 		for (j = 0; j < 64; j++) {
 			uint8 *b = buf + j * 16;
 			memcpy(b, tab + tptr[trk[0][i]][j] * 4, 4);

--- a/src/loaders/prowizard/pp30.c
+++ b/src/loaders/prowizard/pp30.c
@@ -28,9 +28,9 @@ void Depack_PP30 (FILE * in, FILE * out)
 	if (Save_Status == BAD)
 		return;
 
-	memset(ptable, 0, 128);
-	memset(Tracks_Numbers, 0, 4 * 128);
-	memset(Tracks_PrePointers, 0, 512 * 64);
+	memset(ptable, 0, sizeof(ptable));
+	memset(Tracks_Numbers, 0, sizeof(Tracks_Numbers));
+	memset(Tracks_PrePointers, 0, sizeof(Tracks_PrePointers));
 
 	// in = fdopen (fd_in, "rb");
 	// sprintf ( Depacked_OutName , "%ld.mod" , Cpt_Filename-1 );
@@ -127,7 +127,7 @@ void Depack_PP30 (FILE * in, FILE * out)
 
 	/* NOW, the real shit takes place :) */
 	for (i = 0; i < NOP; i++) {
-		memset(Pattern, 0, 1024);
+		memset(Pattern, 0, sizeof(Pattern));
 		for (j = 0; j < 64; j++) {
 
 			Pattern[j * 16] =

--- a/src/loaders/prowizard/prun1.c
+++ b/src/loaders/prowizard/prun1.c
@@ -20,8 +20,8 @@ static int depack_pru1 (HIO_HANDLE *in, FILE *out)
 	int ssize = 0;
 	int i, j;
 
-	memset(header, 0, 2048);
-	memset(ptable, 0, 128);
+	memset(header, 0, sizeof(header));
+	memset(ptable, 0, sizeof(ptable));
 
 	/* read and write whole header */
 	hio_read(header, 950, 1, in);
@@ -35,7 +35,7 @@ static int depack_pru1 (HIO_HANDLE *in, FILE *out)
 	/* read and write size of pattern list */
 	write8(out, npat = hio_read8(in));
 
-	memset(header, 0, 2048);
+	memset(header, 0, sizeof(header));
 
 	/* read and write ntk byte and pattern list */
 	hio_read(header, 129, 1, in);

--- a/src/loaders/prowizard/prun2.c
+++ b/src/loaders/prowizard/prun2.c
@@ -21,9 +21,9 @@ static int depack_pru2(HIO_HANDLE *in, FILE *out)
 	int size, ssize = 0;
 	int i, j;
 
-	memset(header, 0, 2048);
-	memset(ptable, 0, 128);
-	memset(v, 0, 16);
+	memset(header, 0, sizeof(header));
+	memset(ptable, 0, sizeof(ptable));
+	memset(v, 0, sizeof(v));
 
 	pw_write_zero(out, 20);				/* title */
 
@@ -56,7 +56,7 @@ static int depack_pru2(HIO_HANDLE *in, FILE *out)
 	for (i = 0; i <= max; i++) {
 		for (j = 0; j < 256; j++) {
 			uint8 c[4];
-			memset(c, 0, 4);
+			memset(c, 0, sizeof(c));
 			header[0] = hio_read8(in);
 			if (header[0] == 0x80) {
 				write32b(out, 0);

--- a/src/loaders/prowizard/qc.c
+++ b/src/loaders/prowizard/qc.c
@@ -35,10 +35,10 @@ static int depack_emod (HIO_HANDLE *in, FILE *out)
 	long paddr[128];
 	long i = 0, j = 0, k = 0;
 
-	memset(iaddr, 0, 32 * 4);
-	memset(isize, 0, 32 * 4);
-	memset(paddr, 0, 128 * 4);
-	memset(nrow, 0, 128);
+	memset(iaddr, 0, sizeof(iaddr));
+	memset(isize, 0, sizeof(isize));
+	memset(paddr, 0, sizeof(paddr));
+	memset(nrow, 0, sizeof(nrow));
 
 	/* bypass ID's and chunk sizes */
 	fseek (in, 22, 0);
@@ -199,7 +199,7 @@ static int depack_emod (HIO_HANDLE *in, FILE *out)
 
 	/* pattern data */
 	for (i = 0; i <= Real_pat_max; i++) {
-		memset(Pattern, 0, 1024);
+		memset(Pattern, 0, sizeof(Pattern));
 		if (paddr[i] == 0l) {
 			fwrite (Pattern, 1024, 1, out);
 			printf ("-");
@@ -207,7 +207,7 @@ static int depack_emod (HIO_HANDLE *in, FILE *out)
 		}
 		fseek (in, paddr[i], 0);
 		for (j = 0; j <= nrow[i]; j++) {
-			memset(Row, 0, 16);
+			memset(Row, 0, sizeof(Row));
 			fread (Row, 16, 1, in);
 			for (k = 0; k < 4; k++) {
 				/* fxt */

--- a/src/loaders/prowizard/skyt.c
+++ b/src/loaders/prowizard/skyt.c
@@ -20,8 +20,8 @@ static int depack_skyt(HIO_HANDLE *in, FILE *out)
 	int trk_addr;
 	int size, ssize = 0;
 
-	memset(ptable, 0, 128);
-	memset(trkval, 0, 128 * 4);
+	memset(ptable, 0, sizeof(ptable));
+	memset(trkval, 0, sizeof(trkval));
 
 	pw_write_zero(out, 20);			/* write title */
 
@@ -68,7 +68,7 @@ static int depack_skyt(HIO_HANDLE *in, FILE *out)
 
 	/* track data */
 	for (i = 0; i < pat_pos; i++) {
-		memset(pat, 0, 1024);
+		memset(pat, 0, sizeof(pat));
 		for (j = 0; j < 4; j++) {
 			hio_seek(in, trk_addr + ((trkval[i][j] - 1)<<8), SEEK_SET);
 			for (k = 0; k < 64; k++) {

--- a/src/loaders/prowizard/starpack.c
+++ b/src/loaders/prowizard/starpack.c
@@ -26,11 +26,11 @@ static int depack_starpack(HIO_HANDLE *in, FILE *out)
 	int tmp_ptr, tmp1, tmp2;
 	int smp_addr = 0;
 
-	memset(pnum, 0, 128);
-	memset(pnum_tmp, 0, 128);
-	memset(paddr, 0, 128 * 4);
-	memset(paddr_tmp, 0, 128 * 4);
-	memset(paddr_tmp2, 0, 128 * 4);
+	memset(pnum, 0, sizeof(pnum));
+	memset(pnum_tmp, 0, sizeof(pnum_tmp));
+	memset(paddr, 0, sizeof(paddr));
+	memset(paddr_tmp, 0, sizeof(paddr_tmp));
+	memset(paddr_tmp2, 0, sizeof(paddr_tmp2));
 
 	pw_move_data(out, in, 20);		/* title */
 
@@ -127,7 +127,7 @@ static int depack_starpack(HIO_HANDLE *in, FILE *out)
 			}
 	}
 
-	memset(pnum, 0, 128);
+	memset(pnum, 0, sizeof(pnum));
 	for (i = 0; i < pat_pos; i++) {
 		pnum[i] = pnum_tmp[i];
 	}
@@ -151,7 +151,7 @@ static int depack_starpack(HIO_HANDLE *in, FILE *out)
 	/* pattern data */
 	num_pat += 1;
 	for (i = 0; i < num_pat; i++) {
-		memset(buffer, 0, 1024);
+		memset(buffer, 0, sizeof(buffer));
 		for (j = 0; j < 64; j++) {
 			for (k = 0; k < 4; k++) {
 				uint8 c1, c2, c3, c4, c5;

--- a/src/loaders/prowizard/stim.c
+++ b/src/loaders/prowizard/stim.c
@@ -41,12 +41,12 @@ static int depack_stim (uint8 *data, FILE * out)
 	int start = 0;
 	int w = start;	/* main pointer to prevent hio_read() */
 
-	memset(tmp, 0, 1025);
-	memset(ptable, 0, 128);
-	memset(pat, 0, 1025);
-	memset(paddr, 0, 64 * 4);
-	memset(idata_addr, 0, 31 * 4);
-	memset(isize, 0, 31 * 4);
+	memset(tmp, 0, sizeof(tmp));
+	memset(ptable, 0, sizeof(ptable));
+	memset(pat, 0, sizeof(pat));
+	memset(paddr, 0, sizeof(paddr));
+	memset(idata_addr, 0, sizeof(idata_addr));
+	memset(isize, 0, sizeof(isize));
 
 	/* write title */
 	for (i = 0; i < 20; i++)
@@ -144,7 +144,7 @@ static int depack_stim (uint8 *data, FILE * out)
 			taddr[k] = (c1 << 8) + c2;
 		}
 
-		memset(pat, 0, 1025);
+		memset(pat, 0, sizeof(pat));
 		for (k = 0; k < 4; k++) {
 			w = start + paddr[i] + taddr[k];
 			for (j = 0; j < 64; j++) {

--- a/src/loaders/prowizard/tdd.c
+++ b/src/loaders/prowizard/tdd.c
@@ -21,8 +21,8 @@ static int depack_tdd(HIO_HANDLE *in, FILE *out)
 	int saddr[31];
 	int ssizes[31];
 
-	memset(saddr, 0, 31 * 4);
-	memset(ssizes, 0, 31 * 4);
+	memset(saddr, 0, sizeof(saddr));
+	memset(ssizes, 0, sizeof(ssizes));
 
 	/* write ptk header */
 	pw_write_zero(out, 1080);
@@ -76,8 +76,8 @@ static int depack_tdd(HIO_HANDLE *in, FILE *out)
 
 	/* read/write pattern data */
 	for (i = 0; i <= pmax; i++) {
-		memset(tmp, 0, 1024);
-		memset(pat, 0, 1024);
+		memset(tmp, 0, sizeof(tmp));
+		memset(pat, 0, sizeof(pat));
 
 		if (hio_read(tmp, 1, 1024, in) != 1024) {
 			return -1;

--- a/src/loaders/prowizard/theplayer.c
+++ b/src/loaders/prowizard/theplayer.c
@@ -205,10 +205,10 @@ static int theplayer_depack(HIO_HANDLE *in, FILE *out, int version)
 	return -1;
     }
 
-    memset(taddr, 0, 128 * 4 * 4);
-    memset(ptable, 0, 128);
-    memset(smp_size, 0, 31 * 4);
-    memset(isize, 0, 31 * sizeof(int));
+    memset(taddr, 0, sizeof(taddr));
+    memset(ptable, 0, sizeof(ptable));
+    memset(smp_size, 0, sizeof(smp_size));
+    memset(isize, 0, sizeof(isize));
     /*for (i = 0; i < 31; i++) {
 	PACK[i] = 0;
         DELTA[i] = 0;
@@ -324,7 +324,7 @@ static int theplayer_depack(HIO_HANDLE *in, FILE *out, int version)
 
     /* write pattern data */
     for (i = 0; i < npat; i++) {
-	memset(buf, 0, 1024);
+	memset(buf, 0, sizeof(buf));
 	for (j = 0; j < 64; j++) {
 	    for (k = 0; k < 4; k++)
 		memcpy(&buf[j * 16 + k * 4], &track(i, k, j), 4);

--- a/src/loaders/prowizard/titanics.c
+++ b/src/loaders/prowizard/titanics.c
@@ -95,7 +95,7 @@ static int depack_titanics(HIO_HANDLE *in, FILE *out)
 
 		hio_seek(in, pat_addr_final[i], SEEK_SET);
 
-		memset(buf, 0, 1024);
+		memset(buf, 0, sizeof(buf));
 		x = hio_read8(in);
 
 		for (k = 0; k < 64; ) {			/* row number */

--- a/src/loaders/prowizard/tp1.c
+++ b/src/loaders/prowizard/tp1.c
@@ -25,9 +25,9 @@ static int depack_tp1(HIO_HANDLE *in, FILE *out)
 	int size, ssize = 0;
 	int smp_ofs;
 
-	memset(paddr, 0, 128 * 4);
-	memset(paddr_ord, 0, 128 * 4);
-	memset(pnum, 0, 128);
+	memset(paddr, 0, sizeof(paddr));
+	memset(paddr_ord, 0, sizeof(paddr_ord));
+	memset(pnum, 0, sizeof(pnum));
 
 	hio_read32b(in);			/* skip magic */
 	hio_read32b(in);			/* skip size */
@@ -93,7 +93,7 @@ static int depack_tp1(HIO_HANDLE *in, FILE *out)
 		if (hio_seek(in, 794 + paddr_ord[i] - pat_ofs, SEEK_SET) < 0) {
 			return -1;
 		}
-		memset(pdata, 0, 1024);
+		memset(pdata, 0, sizeof(pdata));
 		for (j = 0; j < 256; j++) {
 			uint8 *p = pdata + j * 4;
 

--- a/src/loaders/prowizard/tp2.c
+++ b/src/loaders/prowizard/tp2.c
@@ -35,8 +35,8 @@ void Depack_TP2 (FILE * in, FILE * out)
 	if (Save_Status == BAD)
 		return;
 
-	memset(Track_Address, 0, 128 * 4 * 4);
-	memset(pnum, 0, 128);
+	memset(Track_Address, 0, sizeof(Track_Address));
+	memset(pnum, 0, sizeof(pnum));
 
 	// sprintf ( Depacked_OutName , "%ld.mod" , Cpt_Filename-1 );
 	// out = fdopen (fd_out, "w+b");
@@ -88,7 +88,7 @@ void Depack_TP2 (FILE * in, FILE * out)
 		fwrite (&c2, 1, 1, out);
 
 	}
-	memset(tmp, 0, 30);
+	memset(tmp, 0, sizeof(tmp));
 	tmp[29] = 0x01;
 	while (i != 31) {
 		fwrite (tmp, 30, 1, out);
@@ -154,7 +154,7 @@ void Depack_TP2 (FILE * in, FILE * out)
 	/*printf ( "converting pattern data " ); */
 	for (i = 0; i <= PatMax; i++) {
 /*fprintf ( info , "\npattern %ld:\n\n" , i );*/
-		memset(Pattern, 0, 1024);
+		memset(Pattern, 0, sizeof(Pattern));
 		for (j = 0; j < 4; j++) {
 /*fprintf ( info , "track %ld: (at %ld)\n" , j , Track_Address[i][j]+Start_Pat_Address );*/
 			Where =

--- a/src/loaders/prowizard/tp3.c
+++ b/src/loaders/prowizard/tp3.c
@@ -26,8 +26,8 @@ static int depack_tp23(HIO_HANDLE *in, FILE *out, int ver)
 	int size, ssize = 0;
 	int max_trk_ofs = 0;
 
-	memset(trk_ofs, 0, 128 * 4 * 4);
-	memset(pnum, 0, 128);
+	memset(trk_ofs, 0, sizeof(trk_ofs));
+	memset(pnum, 0, sizeof(pnum));
 
 	hio_seek(in, 8, SEEK_CUR);
 	pw_move_data(out, in, 20);		/* title */
@@ -49,7 +49,7 @@ static int depack_tp23(HIO_HANDLE *in, FILE *out, int ver)
 		write16b(out, hio_read16b(in));	/* loop size */
 	}
 
-	memset(tmp, 0, 30);
+	memset(tmp, 0, sizeof(tmp));
 	tmp[29] = 0x01;
 
 	for (; i < 31; i++) {
@@ -92,7 +92,7 @@ static int depack_tp23(HIO_HANDLE *in, FILE *out, int ver)
 
 	/* pattern datas */
 	for (i = 0; i <= npat; i++) {
-		memset(pdata, 0, 1024);
+		memset(pdata, 0, sizeof(pdata));
 
 		for (j = 0; j < 4; j++) {
 			int where;

--- a/src/loaders/prowizard/xann.c
+++ b/src/loaders/prowizard/xann.c
@@ -25,8 +25,8 @@ static int depack_xann(HIO_HANDLE *in, FILE *out)
 	int size, ssize = 0;
 	int lsize;
 
-	memset(ptable, 0, 128);
-	memset(pdata, 0, 1025);
+	memset(ptable, 0, sizeof(ptable));
+	memset(pdata, 0, sizeof(pdata));
 
 	pw_write_zero(out, 20);			/* title */
 

--- a/src/loaders/prowizard/zen.c
+++ b/src/loaders/prowizard/zen.c
@@ -27,9 +27,9 @@ static int depack_zen(HIO_HANDLE *in, FILE *out)
 	int sdata_addr = 999999l;
 	int i, j, k;
 
-	memset(paddr, 0, 128 * 4);
-	memset(paddr2, 0, 128 * 4);
-	memset(ptable, 0, 128);
+	memset(paddr, 0, sizeof(paddr));
+	memset(paddr2, 0, sizeof(paddr2));
+	memset(ptable, 0, sizeof(ptable));
 
 	ptable_addr = hio_read32b(in);	/* read pattern table address */
 	pat_max = hio_read8(in);	/* read patmax */
@@ -106,7 +106,7 @@ static int depack_zen(HIO_HANDLE *in, FILE *out)
 	/* pattern data */
 	/*printf ( "converting pattern datas " ); */
 	for (i = 0; i <= pat_max; i++) {
-		memset(pat, 0, 1024);
+		memset(pat, 0, sizeof(pat));
 		hio_seek(in, paddr2[i], SEEK_SET);
 		for (j = 0; j < 256; j++) {
 			uint8 *p;

--- a/src/loaders/ptm_load.c
+++ b/src/loaders/ptm_load.c
@@ -257,14 +257,14 @@ static int ptm_load(struct module_data *m, HIO_HANDLE *f, const int start)
 		hio_seek(f, start + 16L * pfh.patseg[i], SEEK_SET);
 		r = 0;
 
-		memset(chn_ctrl, 0, 32);
+		memset(chn_ctrl, 0, sizeof(chn_ctrl));
 
 		while (r < 64) {
 
 			b = hio_read8(f);
 			if (!b) {
 				r++;
-				memset(chn_ctrl, 0, 32);
+				memset(chn_ctrl, 0, sizeof(chn_ctrl));
 				continue;
 			}
 

--- a/src/loaders/sym_load.c
+++ b/src/loaders/sym_load.c
@@ -434,7 +434,7 @@ static int sym_load(struct module_data *m, HIO_HANDLE *f, const int start)
 	for (i = 0; i < mod->ins; i++) {
 		uint8 buf[128];
 
-		memset(buf, 0, 128);
+		memset(buf, 0, sizeof(buf));
 		hio_read(buf, 1, sn[i] & 0x7f, f);
 		libxmp_instrument_name(mod, i, buf, 32);
 


### PR DESCRIPTION
Replaces fixed size values provided to `memset()` in various loaders (particularly ProWizard loaders) with `sizeof(array)` where applicable. Several of these values were not the correct size due to them relying on DOS type sizes. Fixes #170. 